### PR TITLE
Add new http handler SearchDashboardsHandler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,6 @@ golint:
 
 reactlint:
 	cd web/react && yarn lint
+
+go: gobuild golint gotest
+react: reactbuild reactlint reacttest

--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ import (
   }
 
   dashboardsService := dashboards.NewDashboardsService(cfg)
-  dashboard, err := dashboardsService.GetDashboard(model.DashboardQuery{Namespace: "my-namespace", App: "my-app"},
-    "my-dashboard-name")
+  dashboard, err := dashboardsService.GetDashboard(model.DashboardQuery{Namespace: "my-namespace"}, "my-dashboard-name")
 ```
 
 #### Config
@@ -79,9 +78,11 @@ import (
 
 - **PrometheusURL**: URL where the Prometheus server can be reached.
 
-- **Errorf**: handler to an error logging function
+- **Errorf**: optional handler to an error logging function.
 
-- **Tracef**: handler to a tracing logging function
+- **Tracef**: optional handler to a tracing logging function.
+
+- **PodsLoader**: optional pods supplier function, it enables reading dashboard names from pods annotations.
 
 ### React (Javascript / TypeScript)
 
@@ -100,7 +101,7 @@ You can use the react components from `k-charted-react`. Example with `axios`:
   }
 ```
 
-Check out `MetricsOption.ts` file to see how the dashboard can be tuned (filtering by labels, aggregations, etc.)
+Check out [`MetricsOption.ts`](https://github.com/kiali/k-charted/blob/master/web/react/src/types/MetricsOptions.ts) file to see how the dashboard can be tuned (filtering by labels, aggregations, etc.)
 
 ## First build
 

--- a/business/pods.go
+++ b/business/pods.go
@@ -1,0 +1,43 @@
+package business
+
+import (
+	"strings"
+
+	"github.com/kiali/k-charted/model"
+)
+
+func extractUniqueDashboards(pods []model.Pod) []string {
+	// Get uniqueness from plain list rather than map to preserve ordering; anyway, very low amount of objects is expected
+	uniqueRefs := []string{}
+	for _, pod := range pods {
+		// Check for custom dashboards annotation
+		dashboards := extractDashboardsFromAnnotation(pod, "kiali.io/runtimes")
+		dashboards = append(dashboards, extractDashboardsFromAnnotation(pod, "kiali.io/dashboards")...)
+		for _, ref := range dashboards {
+			if ref != "" {
+				exists := false
+				for _, existingRef := range uniqueRefs {
+					if ref == existingRef {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					uniqueRefs = append(uniqueRefs, ref)
+				}
+			}
+		}
+	}
+	return uniqueRefs
+}
+
+func extractDashboardsFromAnnotation(pod model.Pod, annotation string) []string {
+	dashboards := []string{}
+	if rawDashboards, ok := pod.GetAnnotations()[annotation]; ok {
+		rawDashboardsSlice := strings.Split(rawDashboards, ",")
+		for _, dashboard := range rawDashboardsSlice {
+			dashboards = append(dashboards, strings.TrimSpace(dashboard))
+		}
+	}
+	return dashboards
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,11 @@
 package config
 
+import "github.com/kiali/k-charted/model"
+
 type Config struct {
 	PrometheusURL   string `yaml:"prometheus_url,omitempty"`
 	GlobalNamespace string `yaml:"global_namespace,omitempty"`
 	Errorf          func(string, ...interface{})
 	Tracef          func(string, ...interface{})
+	PodsLoader      func(string, string) ([]model.Pod, error)
 }

--- a/http/helper.go
+++ b/http/helper.go
@@ -13,14 +13,7 @@ import (
 
 func ExtractDashboardQueryParams(queryParams url.Values, q *model.DashboardQuery) error {
 	q.FillDefaults()
-	q.LabelsFilters = make(map[string]string)
-	filters := strings.Split(queryParams.Get("labelsFilters"), ",")
-	for _, rawFilter := range filters {
-		kvPair := strings.Split(rawFilter, ":")
-		if len(kvPair) == 2 {
-			q.LabelsFilters[strings.TrimSpace(kvPair[0])] = strings.TrimSpace(kvPair[1])
-		}
-	}
+	q.LabelsFilters = extractLabelsFilters(queryParams.Get("labelsFilters"))
 	additionalLabels := strings.Split(queryParams.Get("additionalLabels"), ",")
 	for _, additionalLabel := range additionalLabels {
 		kvPair := strings.Split(additionalLabel, ":")
@@ -38,6 +31,18 @@ func ExtractDashboardQueryParams(queryParams url.Values, q *model.DashboardQuery
 		q.RawDataAggregator = op
 	}
 	return extractBaseMetricsQueryParams(queryParams, &q.MetricsQuery)
+}
+
+func extractLabelsFilters(rawString string) map[string]string {
+	labelsFilters := make(map[string]string)
+	rawFilters := strings.Split(rawString, ",")
+	for _, rawFilter := range rawFilters {
+		kvPair := strings.Split(rawFilter, ":")
+		if len(kvPair) == 2 {
+			labelsFilters[strings.TrimSpace(kvPair[0])] = strings.TrimSpace(kvPair[1])
+		}
+	}
+	return labelsFilters
 }
 
 func extractBaseMetricsQueryParams(queryParams url.Values, q *prometheus.MetricsQuery) error {

--- a/model/pod.go
+++ b/model/pod.go
@@ -1,0 +1,6 @@
+package model
+
+// Pod is a simple interface to get annotations
+type Pod interface {
+	GetAnnotations() map[string]string
+}


### PR DESCRIPTION
This handler mimics what Kiali does to extract dashboards annotations from pods, without any hard dependency on the k8s Pod model (so, keeps dependencies as light as possible).

