### PR TITLE
KIALI-3050 Allow authenticated access to prometheus

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -40,7 +40,7 @@ func (in *DashboardsService) tracef(format string, args ...interface{}) {
 func (in *DashboardsService) prom() (prometheus.ClientInterface, error) {
 	// Lazy init
 	if in.promClient == nil {
-		client, err := prometheus.NewClient(in.config.PrometheusURL)
+		client, err := prometheus.NewClient(in.config.Prometheus)
 		if err != nil {
 			return nil, fmt.Errorf("cannot initialize Prometheus Client: %v", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,13 @@
 package config
 
-import "github.com/kiali/k-charted/model"
+import (
+	"github.com/kiali/k-charted/config/promconfig"
+	"github.com/kiali/k-charted/model"
+)
 
 type Config struct {
-	PrometheusURL   string `yaml:"prometheus_url,omitempty"`
-	GlobalNamespace string `yaml:"global_namespace,omitempty"`
+	Prometheus      promconfig.PrometheusConfig `yaml:"prometheus"`
+	GlobalNamespace string                      `yaml:"global_namespace"`
 	Errorf          func(string, ...interface{})
 	Tracef          func(string, ...interface{})
 	PodsLoader      func(string, string) ([]model.Pod, error)

--- a/config/promconfig/promconfig.go
+++ b/config/promconfig/promconfig.go
@@ -1,0 +1,25 @@
+package promconfig
+
+// The valid auth strategies and values for cookie handling
+const (
+	// These constants are used for external services auth (Prometheus, Grafana ...) ; not for Kiali auth
+	AuthTypeBasic  = "basic"
+	AuthTypeBearer = "bearer"
+	AuthTypeNone   = "none"
+)
+
+// PrometheusConfig describes configuration of the Prometheus component
+type PrometheusConfig struct {
+	URL  string `yaml:"url"`
+	Auth Auth   `yaml:"auth"`
+}
+
+// Auth provides authentication data for external services
+type Auth struct {
+	Type               string `yaml:"type"`
+	Username           string `yaml:"username"`
+	Password           string `yaml:"password"`
+	Token              string `yaml:"token"`
+	CAFile             string `yaml:"ca_file"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+}

--- a/prometheus/roundtripper.go
+++ b/prometheus/roundtripper.go
@@ -1,0 +1,60 @@
+package prometheus
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/kiali/k-charted/config/promconfig"
+)
+
+type authRoundTripper struct {
+	auth       string
+	originalRT http.RoundTripper
+}
+
+func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", rt.auth)
+	return rt.originalRT.RoundTrip(req)
+}
+
+func newAuthRoundTripper(auth *promconfig.Auth, rt http.RoundTripper) http.RoundTripper {
+	switch auth.Type {
+	case promconfig.AuthTypeBearer:
+		token := auth.Token
+		return &authRoundTripper{auth: "Bearer " + token, originalRT: rt}
+	case promconfig.AuthTypeBasic:
+		encoded := base64.StdEncoding.EncodeToString([]byte(auth.Username + ":" + auth.Password))
+		return &authRoundTripper{auth: "Basic " + encoded, originalRT: rt}
+	default:
+		return rt
+	}
+}
+
+func authTransport(auth *promconfig.Auth, transportConfig *http.Transport) (http.RoundTripper, error) {
+	if auth.InsecureSkipVerify || auth.CAFile != "" {
+		var certPool *x509.CertPool
+		if auth.CAFile != "" {
+			certPool = x509.NewCertPool()
+			cert, err := ioutil.ReadFile(auth.CAFile)
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to get root CA certificates: %s", err)
+			}
+
+			if ok := certPool.AppendCertsFromPEM(cert); !ok {
+				return nil, fmt.Errorf("supplied CA file could not be parsed")
+			}
+		}
+
+		transportConfig.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: auth.InsecureSkipVerify,
+			RootCAs:            certPool,
+		}
+	}
+
+	return newAuthRoundTripper(auth, transportConfig), nil
+}


### PR DESCRIPTION
Doing here similar implementation as what was done in Kiali, allowing basic auth, oauth/token, ssl, insecure ...