### PR TITLE
Adding more tests (see KIALI-3069)

### DIFF
--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -7,7 +7,7 @@ import (
 
 	pmodel "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/k-charted/config"
 	kmock "github.com/kiali/k-charted/kubernetes/mock"
@@ -252,4 +252,52 @@ func fakeDashboard(id string) *v1alpha1.MonitoringDashboard {
 			},
 		},
 	}
+}
+
+func TestConvertEmptyMetric(t *testing.T) {
+	assert := assert.New(t)
+	in := NewDashboardsService(config.Config{})
+	var metric prometheus.Metric
+
+	// Make sure metric is never nil, but empty slice
+	res, err := in.convertMetric(metric, "foo")
+	assert.Empty(err)
+	assert.NotNil(res)
+	assert.Len(res, 0)
+
+	metric.Err = errors.New("Some error")
+	res, err = in.convertMetric(metric, "foo")
+	assert.Equal("Some error", err)
+	assert.NotNil(res)
+	assert.Len(res, 0)
+}
+
+func TestConvertEmptyHistogram(t *testing.T) {
+	assert := assert.New(t)
+	in := NewDashboardsService(config.Config{})
+	var histo prometheus.Histogram
+
+	// An empty histogram gives an empty map
+	res, err := in.convertHistogram(histo, "foo")
+	assert.Empty(err)
+	assert.NotNil(res)
+	assert.Len(res, 0)
+
+	// ... But empty metrics within an histogram cannot be nil
+	histo = make(prometheus.Histogram)
+	var metric prometheus.Metric
+	histo["0.99"] = metric
+	res, err = in.convertHistogram(histo, "foo")
+	assert.Empty(err)
+	assert.NotNil(res)
+	assert.Len(res, 1)
+	assert.NotNil(res["0.99"])
+	assert.Len(res["0.99"], 0)
+
+	// Check with error (here, histogram is nil)
+	metric.Err = errors.New("Some error")
+	histo["0.99"] = metric
+	res, err = in.convertHistogram(histo, "foo")
+	assert.Equal("Some error", err)
+	assert.Nil(res)
 }

--- a/model/dashboards_test.go
+++ b/model/dashboards_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	pmod "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/k-charted/kubernetes/v1alpha1"
@@ -79,4 +80,14 @@ func TestJSONMarshallingNaN(t *testing.T) {
 	res, err := json.Marshal(samplePair)
 	assert.Nil(err)
 	assert.Equal("[123456.789,\"NaN\"]", string(res))
+}
+
+func TestConvertEmptyMatrix(t *testing.T) {
+	assert := assert.New(t)
+	var matrix pmod.Matrix
+
+	// Make sure matrices are never nil, but empty slices
+	res := ConvertMatrix(matrix)
+	assert.NotNil(res)
+	assert.Len(res, 0)
 }


### PR DESCRIPTION
Add tests to make sure we never produce nil-slices before json serialization

See comments in https://issues.jboss.org/browse/KIALI-3069