### PR TITLE
Convert values explicitely into numbers (issue #24)

### DIFF
--- a/web/pf4/src/utils/victoryChartsUtils.ts
+++ b/web/pf4/src/utils/victoryChartsUtils.ts
@@ -13,7 +13,7 @@ const toVCLines = (ts: TimeSeries[]): VictoryChartInfo => {
         return {
           name: line.name!,
           x: new Date(dp[0] * 1000) as any,
-          y: dp[1]
+          y: Number(dp[1])
         };
       });
     })


### PR DESCRIPTION
**Before** (note the Y-axis values unordered, because they are seen as strings):

![before](https://i.imgur.com/1UnO6Nq.png)

**After**:

![after](https://i.imgur.com/OoUMGth.png)