### PR TITLE
Allow to specify chart type and y-domain with dashboard spec

### DIFF
--- a/kubernetes/v1alpha1/spec.go
+++ b/kubernetes/v1alpha1/spec.go
@@ -52,6 +52,9 @@ type MonitoringDashboardChart struct {
 	Name         string                           `json:"name"`
 	Unit         string                           `json:"unit"`
 	Spans        int                              `json:"spans"`
+	ChartType    *string                          `json:"chartType"`
+	Min          *int                             `json:"min"`
+	Max          *int                             `json:"max"`
 	MetricName   string                           `json:"metricName"`
 	DataType     string                           `json:"dataType"`   // DataType is either "raw", "rate" or "histogram"
 	Aggregator   string                           `json:"aggregator"` // Aggregator can be set for raw data. Ex: "sum", "avg". See https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators

--- a/model/dashboards.go
+++ b/model/dashboards.go
@@ -20,6 +20,9 @@ type Chart struct {
 	Name      string                     `json:"name"`
 	Unit      string                     `json:"unit"`
 	Spans     int                        `json:"spans"`
+	ChartType *string                    `json:"chartType,omitempty"`
+	Min       *int                       `json:"min,omitempty"`
+	Max       *int                       `json:"max,omitempty"`
 	Metric    []*SampleStream            `json:"metric"`
 	Histogram map[string][]*SampleStream `json:"histogram"`
 	Error     string                     `json:"error"`
@@ -76,9 +79,12 @@ func convertSamplePair(from *pmod.SamplePair) SamplePair {
 // ConvertChart converts a k8s chart (from MonitoringDashboard k8s resource) into this models chart
 func ConvertChart(from v1alpha1.MonitoringDashboardChart) Chart {
 	return Chart{
-		Name:  from.Name,
-		Unit:  from.Unit,
-		Spans: from.Spans,
+		Name:      from.Name,
+		Unit:      from.Unit,
+		Spans:     from.Spans,
+		ChartType: from.ChartType,
+		Min:       from.Min,
+		Max:       from.Max,
 	}
 }
 

--- a/web/common/types/Dashboards.ts
+++ b/web/common/types/Dashboards.ts
@@ -8,11 +8,15 @@ export interface DashboardModel {
 }
 
 export type SpanValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type ChartType = 'area' | 'line' | 'bar';
 
 export interface ChartModel {
   name: string;
   unit: string;
   spans: SpanValue;
+  chartType?: ChartType;
+  min?: number;
+  max?: number;
   metric?: TimeSeries[];
   histogram?: Histogram;
   error?: string;

--- a/web/pf4/src/components/KChart.stories.tsx
+++ b/web/pf4/src/components/KChart.stories.tsx
@@ -9,10 +9,33 @@ import '@patternfly/react-core/dist/styles/base.css';
 const metric = generateRandomMetricChart('Random metric chart', ['dogs', 'cats', 'birds'], 12, 'kchart-seed');
 const histogram = generateRandomHistogramChart('Random histogram chart', 12, 'kchart-histo-seed');
 
+const reset = () => {
+  metric.chartType = undefined;
+  metric.min = undefined;
+  metric.max = undefined;
+};
+
 storiesOf('PF4 KChart', module)
-  .add('with data', () => (
-    <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />
-  ))
+  .add('as lines', () => {
+    reset();
+    return <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />;
+  })
+  .add('as areas', () => {
+    reset();
+    metric.chartType = 'area';
+    return <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />;
+  })
+  .add('as bars', () => {
+    reset();
+    metric.chartType = 'bar';
+    return <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />;
+  })
+  .add('with min=20, max=100', () => {
+    reset();
+    metric.min = 20;
+    metric.max = 100;
+    return <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />;
+  })
   .add('histogram', () => (
     <KChart chart={histogram} dataSupplier={getDataSupplier(histogram, new Map())!} />
   ))

--- a/web/pf4/src/components/KChart.tsx
+++ b/web/pf4/src/components/KChart.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { style } from 'typestyle';
 import { Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { Chart, ChartArea, ChartGroup, ChartLegend, ChartVoronoiContainer, ChartThemeColor, ChartAxis, ChartTooltip } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartBar, ChartLine, ChartGroup, ChartLegend, ChartVoronoiContainer, ChartThemeColor, ChartAxis, ChartTooltip } from '@patternfly/react-charts';
 import { ExpandArrowsAltIcon, InfoAltIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
 import { format as d3Format } from 'd3-format';
 
@@ -121,6 +121,14 @@ class KChart extends React.Component<KChartProps, State> {
       />
     );
     const scaleInfo = this.scaledAxisInfo(data);
+    const seriesBuilder = (this.props.chart.chartType === 'area')
+      ? (line, idx) => (<ChartArea key={'line-' + idx} data={line} />)
+      : (this.props.chart.chartType === 'bar')
+      ? (line, idx) => (<ChartBar key={'line-' + idx} data={line} />)
+      : (line, idx) => (<ChartLine key={'line-' + idx} data={line} />);
+    const groupOffset = this.props.chart.chartType === 'bar' ? 7 : 0;
+    const minDomain = this.props.chart.min === undefined ? undefined : { y: this.props.chart.min };
+    const maxDomain = this.props.chart.max === undefined ? undefined : { y: this.props.chart.max };
 
     return (
       <div ref={this.containerRef}>
@@ -132,7 +140,10 @@ class KChart extends React.Component<KChartProps, State> {
             height={height}
             width={this.state.width}
             themeColor={ChartThemeColor.multi}
-            scale={{x: 'time'}}>
+            scale={{x: 'time'}}
+            minDomain={minDomain}
+            maxDomain={maxDomain}>
+            <ChartGroup offset={groupOffset}>{data.series.map(seriesBuilder)}</ChartGroup>
             <ChartAxis
               tickCount={scaleInfo.count}
               style={{ tickLabels: {fontSize: 12, padding: 2} }}
@@ -143,11 +154,6 @@ class KChart extends React.Component<KChartProps, State> {
               tickFormat={formatter}
               style={{ tickLabels: {fontSize: 12, padding: 2} }}
             />
-            <ChartGroup>
-              {data.series.map((line, idx) => {
-                return (<ChartArea key={'line-' + idx} data={line} />);
-              })}
-            </ChartGroup>
           </Chart>
         </div>
         <ChartLegend

--- a/web/pf4/src/components/KChart.tsx
+++ b/web/pf4/src/components/KChart.tsx
@@ -121,11 +121,10 @@ class KChart extends React.Component<KChartProps, State> {
       />
     );
     const scaleInfo = this.scaledAxisInfo(data);
-    const seriesBuilder = (this.props.chart.chartType === 'area')
-      ? (line, idx) => (<ChartArea key={'line-' + idx} data={line} />)
-      : (this.props.chart.chartType === 'bar')
-      ? (line, idx) => (<ChartBar key={'line-' + idx} data={line} />)
-      : (line, idx) => (<ChartLine key={'line-' + idx} data={line} />);
+    const seriesBuilder =
+      (this.props.chart.chartType === 'area') ? (serie, idx) => (<ChartArea key={'serie-' + idx} data={serie} />) :
+      (this.props.chart.chartType === 'bar')  ? (serie, idx) => (<ChartBar key={'serie-' + idx} data={serie} />) :
+                                                (serie, idx) => (<ChartLine key={'serie-' + idx} data={serie} />);
     const groupOffset = this.props.chart.chartType === 'bar' ? 7 : 0;
     const minDomain = this.props.chart.min === undefined ? undefined : { y: this.props.chart.min };
     const maxDomain = this.props.chart.max === undefined ? undefined : { y: this.props.chart.max };


### PR DESCRIPTION
Available chart types are 'line', 'area' and 'bar'. Defaults to 'line'.
Y-domain refers to min & max on Y values.

Addresses both #41 and #14