### PR TITLE
Workaround for VictoryVoronoiContainer crash 

### DIFF
--- a/web/pf4/src/components/Container.tsx
+++ b/web/pf4/src/components/Container.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { format as d3Format } from 'd3-format';
+import { getFormatter } from '../../../common/utils/formatter';
+import { ChartVoronoiContainer, ChartTooltip } from '@patternfly/react-charts';
+
+export const createContainer = () => {
+  const tooltip = (
+    <ChartTooltip
+      style={{ stroke: 'none', fill: 'white' }}
+      renderInPortal={true}
+    />
+  );
+  return (
+    <ChartVoronoiContainer
+      labels={dp => `${dp.name}: ${getFormatter(d3Format, dp.unit)(dp.y)}`}
+      labelComponent={tooltip}
+    />
+  );
+};

--- a/web/pf4/src/components/Container.tsx
+++ b/web/pf4/src/components/Container.tsx
@@ -14,6 +14,9 @@ export const createContainer = () => {
     <ChartVoronoiContainer
       labels={dp => `${dp.name}: ${getFormatter(d3Format, dp.unit)(dp.y)}`}
       labelComponent={tooltip}
+      // We blacklist "parent" as a workaround to avoid the VictoryVoronoiContainer crashing.
+      // See https://github.com/FormidableLabs/victory/issues/1355
+      voronoiBlacklist={['parent']}
     />
   );
 };

--- a/web/pf4/src/components/Dashboard.stories.tsx
+++ b/web/pf4/src/components/Dashboard.stories.tsx
@@ -5,9 +5,11 @@ import { emptyDashboard, generateRandomDashboard } from '../types/__mocks__/Dash
 
 import '@patternfly/react-core/dist/styles/base.css';
 
+const labels = new Map([['color', { 'green': true, 'orange': true, 'yellow': true }]]);
+
 storiesOf('PF4 Dashboard', module)
   .add('with data', () => (
-    <Dashboard dashboard={generateRandomDashboard('Dashboard with data', 'dashboard-seed')} labelValues={new Map()} expandHandler={() => {}} />
+    <Dashboard dashboard={generateRandomDashboard('Dashboard with data', 'dashboard-seed')} labelValues={labels} expandHandler={() => {}} />
   ))
   .add('empty', () => (
     <Dashboard dashboard={emptyDashboard} labelValues={new Map()} expandHandler={() => {}} />

--- a/web/pf4/src/components/Dashboard.tsx
+++ b/web/pf4/src/components/Dashboard.tsx
@@ -81,7 +81,7 @@ export class Dashboard extends React.Component<Props, State> {
         <KChart
           key={chart.name}
           chart={chart}
-          dataSupplier={dataSupplier}
+          data={dataSupplier()}
           expandHandler={expandHandler}
         />
       );

--- a/web/pf4/src/components/KChart.stories.tsx
+++ b/web/pf4/src/components/KChart.stories.tsx
@@ -18,30 +18,30 @@ const reset = () => {
 storiesOf('PF4 KChart', module)
   .add('as lines', () => {
     reset();
-    return <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />;
+    return <KChart chart={metric} data={getDataSupplier(metric, new Map())!()} />;
   })
   .add('as areas', () => {
     reset();
     metric.chartType = 'area';
-    return <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />;
+    return <KChart chart={metric} data={getDataSupplier(metric, new Map())!()} />;
   })
   .add('as bars', () => {
     reset();
     metric.chartType = 'bar';
-    return <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />;
+    return <KChart chart={metric} data={getDataSupplier(metric, new Map())!()} />;
   })
   .add('with min=20, max=100', () => {
     reset();
     metric.min = 20;
     metric.max = 100;
-    return <KChart chart={metric} dataSupplier={getDataSupplier(metric, new Map())!} />;
+    return <KChart chart={metric} data={getDataSupplier(metric, new Map())!()} />;
   })
   .add('histogram', () => (
-    <KChart chart={histogram} dataSupplier={getDataSupplier(histogram, new Map())!} />
+    <KChart chart={histogram} data={getDataSupplier(histogram, new Map())!()} />
   ))
   .add('empty', () => (
-    <KChart chart={empty} dataSupplier={getDataSupplier(empty, new Map())!} />
+    <KChart chart={empty} data={getDataSupplier(empty, new Map())!()} />
   ))
   .add('with error', () => (
-    <KChart chart={error} dataSupplier={getDataSupplier(empty, new Map())!} />
+    <KChart chart={error} data={getDataSupplier(empty, new Map())!()} />
   ));

--- a/web/pf4/src/types/__mocks__/Charts.mock.ts
+++ b/web/pf4/src/types/__mocks__/Charts.mock.ts
@@ -5,11 +5,14 @@ import seedrandom from 'seedrandom';
 const t0 = 1556802000;
 const increment = 60;
 
-const genSeries = (names: string[]): TimeSeries[] => {
-  return names.map(name => {
+type MetricMock = { name: string, labels: { [key: string]: string } };
+
+const genSeries = (metrics: MetricMock[]): TimeSeries[] => {
+  return metrics.map(m => {
+    m.labels.__name__ = m.name;
     return {
       values: genSingle(0, 50),
-      labelSet: { lbl: name }
+      labelSet: m.labels
     };
   });
 };
@@ -32,7 +35,19 @@ export const generateRandomMetricChart = (title: string, names: string[], spans:
     name: title,
     unit: 'bytes',
     spans: spans,
-    metric: genSeries(names)
+    metric: genSeries(names.map(n => ({ name: n, labels: {}})))
+  };
+};
+
+export const generateRandomMetricChartWithLabels = (title: string, metrics: MetricMock[], spans: SpanValue, seed?: string): ChartModel => {
+  if (seed) {
+    seedrandom(seed, { global: true });
+  }
+  return {
+    name: title,
+    unit: 'bytes',
+    spans: spans,
+    metric: genSeries(metrics)
   };
 };
 

--- a/web/pf4/src/types/__mocks__/Dashboards.mock.ts
+++ b/web/pf4/src/types/__mocks__/Dashboards.mock.ts
@@ -1,6 +1,6 @@
 import { DashboardModel } from '../../../../common/types/Dashboards';
 import seedrandom from 'seedrandom';
-import { generateRandomMetricChart, generateRandomHistogramChart } from './Charts.mock';
+import { generateRandomMetricChart, generateRandomMetricChartWithLabels, generateRandomHistogramChart } from './Charts.mock';
 
 export const generateRandomDashboard = (title: string, seed?: string): DashboardModel => {
   if (seed) {
@@ -10,8 +10,8 @@ export const generateRandomDashboard = (title: string, seed?: string): Dashboard
     title: title,
     charts: [
       generateRandomMetricChart('Best animal', ['dogs', 'cats', 'birds'], 4),
-      generateRandomMetricChart('Best fruit', ['apples', 'oranges', 'bananas'], 4),
-      generateRandomHistogramChart('Animal histogram', 4),
+      generateRandomMetricChartWithLabels('Best fruit', [{name: 'apples', labels: {color: 'green'}}, {name: 'oranges', labels: {color: 'orange'}}, {name: 'bananas', labels: {color: 'yellow'}}], 4),
+      generateRandomHistogramChart('Histogram', 4),
       generateRandomMetricChart('Best animal++', ['dogs', 'cats', 'birds', 'stunning animal with very very long name that you\'ve never about', 'mermaids', 'escherichia coli', 'wohlfahrtiimonas', 'Chuck Norris'], 6),
       generateRandomMetricChart('Best fruit++', ['apples', 'oranges', 'bananas', 'peaches', 'peers', 'cherries', 'leetchies', 'pineapple'], 6),
     ],


### PR DESCRIPTION
This is a workaround for FormidableLabs/victory#1355
It seems to relate to events sent on behalf of 'parent' svg when charts are being reloaded. The issue was not seen in k-charted / storybook, but in Kiali, probably some racy condition.

Adding several small enhancements at the same time (different commit):

- Fix href warning
- Add story for chart with labels
- Move container creation out of chart
