### PR TITLE
Rename 'quantile 0.xx' => pxx

### DIFF
--- a/web/common/utils/timeSeriesUtils.ts
+++ b/web/common/utils/timeSeriesUtils.ts
@@ -23,13 +23,23 @@ export const filterAndNameHistogram = (histogram: Histogram, labelValues: AllPro
   const filtered: Histogram = {};
   Object.keys(histogram).forEach(stat => {
     filtered[stat] = histogram[stat].filter(ts => isVisibleMetric(ts.labelSet, labelValues));
-    const statName = stat === 'avg' ? 'average' : 'quantile ' + stat;
-    nameHistogramStat(filtered[stat], statName);
+    nameHistogramStat(filtered[stat], stat);
   });
   return filtered;
 };
 
+const mapStatForDisplay = (stat: string): string => {
+  switch (stat) {
+    case '0.5': return 'p50';
+    case '0.95': return 'p95';
+    case '0.99': return 'p99';
+    case '0.999': return 'p99.9';
+    default: return stat;
+  }
+};
+
 const nameHistogramStat = (matrix: TimeSeries[], stat: string): TimeSeries[] => {
+  const statDisplay = mapStatForDisplay(stat);
   matrix.forEach(ts => {
     const labels = Object.keys(ts.labelSet)
       .filter(k => k !== 'reporter')
@@ -37,10 +47,10 @@ const nameHistogramStat = (matrix: TimeSeries[], stat: string): TimeSeries[] => 
       .join(',');
     if (labels === '') {
       // Ex: average // quantile 0.999 // etc.
-      ts.name = stat;
+      ts.name = statDisplay;
     } else {
       // Ex: policy: average // stadium: quantile 0.999 // etc.
-      ts.name = `${labels}: ${stat}`;
+      ts.name = `${labels}: ${statDisplay}`;
     }
   });
   return matrix;

--- a/web/pf3/src/utils/__tests__/c3ChartsUtils.test.ts
+++ b/web/pf3/src/utils/__tests__/c3ChartsUtils.test.ts
@@ -20,8 +20,8 @@ describe('C3 Charts Utils', () => {
     const res = getDataSupplier(histogram, new Map())!();
     expect(res.columns).toHaveLength(3);
     expect(res.columns[0]).toEqual(['x', 1556802000000, 1556802060000, 1556802120000]);
-    expect(res.columns[1]).toEqual(['average', 50.4, 48.2, 42]);
-    expect(res.columns[2]).toEqual(['quantile 0.99', 150.4, 148.2, 142]);
+    expect(res.columns[1]).toEqual(['avg', 50.4, 48.2, 42]);
+    expect(res.columns[2]).toEqual(['p99', 150.4, 148.2, 142]);
   });
 
   it('should normalize with ealier metric', () => {

--- a/web/pf4/src/utils/__tests__/victoryChartsUtils.test.ts
+++ b/web/pf4/src/utils/__tests__/victoryChartsUtils.test.ts
@@ -28,10 +28,10 @@ describe('Victory Charts Utils', () => {
     expect(res.series).toHaveLength(2);
     expect(res.series[0].map(s => s.x)).toEqual([t0, t1, t2]);
     expect(res.series[0].map(s => s.y)).toEqual([50.4, 48.2, 42]);
-    expect(res.series[0].map(s => s.name)).toEqual(['average', 'average', 'average']);
+    expect(res.series[0].map(s => s.name)).toEqual(['avg', 'avg', 'avg']);
     expect(res.series[1].map(s => s.x)).toEqual([t0, t1, t2]);
     expect(res.series[1].map(s => s.y)).toEqual([150.4, 148.2, 142]);
-    expect(res.series[1].map(s => s.name)).toEqual(['quantile 0.99', 'quantile 0.99', 'quantile 0.99']);
+    expect(res.series[1].map(s => s.name)).toEqual(['p99', 'p99', 'p99']);
   });
 
   it('should ignore NaN values', () => {


### PR DESCRIPTION
'average' is also shortened to 'avg'.

This is a better fit for large legends.

Fixes #39 