### PR TITLE
Manage external links to grafana dashboards within CR

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Then, assuming the repos are located within your $GOPATH, run:
 cd ${GOPATH}/src/github.com/kiali/kiali
 glide mirror set https://github.com/kiali/k-charted file://${GOPATH}/src/github.com/kiali/k-charted
 
+# Edit Kiali glide.yaml to point k-charted to your commit SHA
 # Then, update your dependencies. In Kiali:
 make dep-update
 ```

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kiali/k-charted/config"
 	"github.com/kiali/k-charted/kubernetes"
 	"github.com/kiali/k-charted/kubernetes/v1alpha1"
+	"github.com/kiali/k-charted/log"
 	"github.com/kiali/k-charted/model"
 	"github.com/kiali/k-charted/prometheus"
 )
@@ -18,22 +19,14 @@ type DashboardsService struct {
 	promClient prometheus.ClientInterface
 	k8sClient  kubernetes.ClientInterface
 	config     config.Config
+	Logger     log.SafeAdapter
 }
 
 // NewDashboardsService initializes this business service
-func NewDashboardsService(conf config.Config) DashboardsService {
-	return DashboardsService{config: conf}
-}
-
-func (in *DashboardsService) errorf(format string, args ...interface{}) {
-	if in.config.Errorf != nil {
-		in.config.Errorf(format, args...)
-	}
-}
-
-func (in *DashboardsService) tracef(format string, args ...interface{}) {
-	if in.config.Tracef != nil {
-		in.config.Tracef(format, args...)
+func NewDashboardsService(conf config.Config, logger log.LogAdapter) DashboardsService {
+	return DashboardsService{
+		config: conf,
+		Logger: log.NewSafeAdapter(logger),
 	}
 }
 
@@ -67,7 +60,7 @@ func (in *DashboardsService) k8sGetDashboard(namespace, template string) (*v1alp
 	if err != nil {
 		return nil, err
 	}
-	in.tracef("load k8s dashboard '%s' in namespace '%s'", template, namespace)
+	in.Logger.Tracef("load k8s dashboard '%s' in namespace '%s'", template, namespace)
 	return client.GetDashboard(namespace, template)
 }
 
@@ -77,7 +70,7 @@ func (in *DashboardsService) k8sGetDashboards(namespace string) ([]v1alpha1.Moni
 	if err != nil {
 		return nil, err
 	}
-	in.tracef("load all k8s dashboards in namespace '%s'", namespace)
+	in.Logger.Tracef("load all k8s dashboards in namespace '%s'", namespace)
 	return client.GetDashboards(namespace)
 }
 
@@ -191,7 +184,7 @@ func (in *DashboardsService) GetDashboard(params model.DashboardQuery, template 
 	grouping := strings.Join(params.ByLabels, ",")
 
 	wg := sync.WaitGroup{}
-	wg.Add(len(dashboard.Spec.Items))
+	wg.Add(len(dashboard.Spec.Items) + 1)
 	filledCharts := make([]model.Chart, len(dashboard.Spec.Items))
 
 	for i, item := range dashboard.Spec.Items {
@@ -215,11 +208,26 @@ func (in *DashboardsService) GetDashboard(params model.DashboardQuery, template 
 		}(i, item.Chart)
 	}
 
+	var externalLinks []model.ExternalLink
+	go func() {
+		defer wg.Done()
+		links, _, err := GetGrafanaLinks(in.Logger, in.config.Grafana, dashboard.Spec.ExternalLinks)
+		if err != nil {
+			in.Logger.Errorf("Error while getting Grafana links: %v", err)
+		}
+		if links != nil {
+			externalLinks = links
+		} else {
+			externalLinks = []model.ExternalLink{}
+		}
+	}()
+
 	wg.Wait()
 	return &model.MonitoringDashboard{
-		Title:        dashboard.Spec.Title,
-		Charts:       filledCharts,
-		Aggregations: aggLabels,
+		Title:         dashboard.Spec.Title,
+		Charts:        filledCharts,
+		Aggregations:  aggLabels,
+		ExternalLinks: externalLinks,
 	}, nil
 }
 
@@ -237,7 +245,7 @@ func (in *DashboardsService) convertHistogram(from prometheus.Histogram, name st
 
 func (in *DashboardsService) convertMetric(from prometheus.Metric, name string) ([]*model.SampleStream, string) {
 	if from.Err != nil {
-		in.errorf("error in metric %s: %v", name, from.Err)
+		in.Logger.Errorf("error in metric %s: %v", name, from.Err)
 		return []*model.SampleStream{}, from.Err.Error()
 	}
 	return model.ConvertMatrix(from.Matrix), ""
@@ -248,7 +256,7 @@ func (in *DashboardsService) convertMetric(from prometheus.Metric, name string) 
 func (in *DashboardsService) SearchExplicitDashboards(namespace string, pods []model.Pod) []model.Runtime {
 	uniqueRefsList := extractUniqueDashboards(pods)
 	if len(uniqueRefsList) > 0 {
-		in.tracef("getting dashboards from refs list: %v", uniqueRefsList)
+		in.Logger.Tracef("getting dashboards from refs list: %v", uniqueRefsList)
 		return in.buildRuntimesList(namespace, uniqueRefsList)
 	}
 	return []model.Runtime{}
@@ -263,7 +271,7 @@ func (in *DashboardsService) buildRuntimesList(namespace string, templatesNames 
 			defer wg.Done()
 			dashboard, err := in.loadRawDashboardResource(namespace, tpl)
 			if err != nil {
-				in.errorf("cannot get dashboard %s in namespace %s. Error was: %v", tpl, namespace, err)
+				in.Logger.Errorf("cannot get dashboard %s in namespace %s. Error was: %v", tpl, namespace, err)
 			} else {
 				dashboards[i] = dashboard
 			}
@@ -291,14 +299,14 @@ func (in *DashboardsService) fetchMetricNames(namespace string, labelsFilters ma
 	labels := in.buildLabels(namespace, labelsFilters)
 	metrics, err := promClient.GetMetricsForLabels([]string{labels})
 	if err != nil {
-		in.errorf("runtimes discovery failed, cannot load metrics for labels: %s. Error was: %v", labels, err)
+		in.Logger.Errorf("runtimes discovery failed, cannot load metrics for labels: %s. Error was: %v", labels, err)
 	}
 	return metrics
 }
 
 // DiscoverDashboards tries to discover dashboards based on existing metrics
 func (in *DashboardsService) DiscoverDashboards(namespace string, labelsFilters map[string]string) []model.Runtime {
-	in.tracef("starting runtimes discovery on namespace %s with filters [%v]", namespace, labelsFilters)
+	in.Logger.Tracef("starting runtimes discovery on namespace %s with filters [%v]", namespace, labelsFilters)
 
 	var metrics []string
 	wg := sync.WaitGroup{}
@@ -310,7 +318,7 @@ func (in *DashboardsService) DiscoverDashboards(namespace string, labelsFilters 
 
 	allDashboards, err := in.loadRawDashboardResources(namespace)
 	if err != nil {
-		in.errorf("runtimes discovery failed, cannot load dashboards in namespace %s. Error was: %v", namespace, err)
+		in.Logger.Errorf("runtimes discovery failed, cannot load dashboards in namespace %s. Error was: %v", namespace, err)
 		return []model.Runtime{}
 	}
 

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kiali/k-charted/config"
 	kmock "github.com/kiali/k-charted/kubernetes/mock"
 	"github.com/kiali/k-charted/kubernetes/v1alpha1"
+	"github.com/kiali/k-charted/log"
 	"github.com/kiali/k-charted/model"
 	"github.com/kiali/k-charted/prometheus"
 	pmock "github.com/kiali/k-charted/prometheus/mock"
@@ -20,8 +21,7 @@ import (
 func setupService() (*DashboardsService, *kmock.ClientMock, *pmock.PromClientMock) {
 	k8s := new(kmock.ClientMock)
 	prom := new(pmock.PromClientMock)
-	service := NewDashboardsService(config.Config{
-		GlobalNamespace: "istio-system",
+	service := NewDashboardsService(config.Config{GlobalNamespace: "istio-system"}, log.LogAdapter{
 		Errorf: func(s string, args ...interface{}) {
 			fmt.Printf(s+"\n", args...)
 		},
@@ -256,7 +256,7 @@ func fakeDashboard(id string) *v1alpha1.MonitoringDashboard {
 
 func TestConvertEmptyMetric(t *testing.T) {
 	assert := assert.New(t)
-	in := NewDashboardsService(config.Config{})
+	in := NewDashboardsService(config.Config{}, log.LogAdapter{})
 	var metric prometheus.Metric
 
 	// Make sure metric is never nil, but empty slice
@@ -274,7 +274,7 @@ func TestConvertEmptyMetric(t *testing.T) {
 
 func TestConvertEmptyHistogram(t *testing.T) {
 	assert := assert.New(t)
-	in := NewDashboardsService(config.Config{})
+	in := NewDashboardsService(config.Config{}, log.LogAdapter{})
 	var histo prometheus.Histogram
 
 	// An empty histogram gives an empty map

--- a/business/grafana.go
+++ b/business/grafana.go
@@ -1,0 +1,100 @@
+package business
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/kiali/k-charted/config/extconfig"
+	"github.com/kiali/k-charted/httputil"
+	"github.com/kiali/k-charted/kubernetes/v1alpha1"
+	"github.com/kiali/k-charted/log"
+	"github.com/kiali/k-charted/model"
+)
+
+type dashboardSupplier func(string, string, *extconfig.Auth) ([]byte, int, error)
+
+// GetGrafanaLinks returns the links to Grafana dashboards and other info, the HTTP status code (int) and eventually an error
+func GetGrafanaLinks(logger log.SafeAdapter, cfg extconfig.GrafanaConfig, linksSpec []v1alpha1.MonitoringDashboardExternalLink) ([]model.ExternalLink, int, error) {
+	if cfg.URL == "" {
+		logger.Tracef("Skip checking Grafana links as Grafana is not configured")
+		return nil, 0, nil
+	}
+	return getGrafanaLinks(logger, cfg, linksSpec, findDashboard)
+}
+
+func getGrafanaLinks(logger log.SafeAdapter, cfg extconfig.GrafanaConfig, linksSpec []v1alpha1.MonitoringDashboardExternalLink, dashboardSupplier dashboardSupplier) ([]model.ExternalLink, int, error) {
+	apiURL := cfg.URL
+
+	// Find the in-cluster URL to reach Grafana's REST API if properties demand so
+	if cfg.InClusterURL != "" {
+		apiURL = cfg.InClusterURL
+	}
+
+	// Call Grafana REST API to get dashboard urls
+	linksOut := []model.ExternalLink{}
+	for _, linkSpec := range linksSpec {
+		if linkSpec.Type == "grafana" {
+			dashboardPath, err := getDashboardPath(logger, apiURL, linkSpec.Name, &cfg.Auth, dashboardSupplier)
+			if err != nil {
+				return nil, http.StatusServiceUnavailable, err
+			}
+			if dashboardPath != "" {
+				linkOut := model.ExternalLink{
+					URL:       cfg.URL + dashboardPath,
+					Name:      linkSpec.Name,
+					Variables: linkSpec.Variables,
+				}
+				linksOut = append(linksOut, linkOut)
+			}
+		}
+	}
+
+	return linksOut, http.StatusOK, nil
+}
+
+func getDashboardPath(logger log.SafeAdapter, basePath, name string, auth *extconfig.Auth, dashboardSupplier dashboardSupplier) (string, error) {
+	body, code, err := dashboardSupplier(basePath, url.PathEscape(name), auth)
+	if err != nil {
+		return "", err
+	}
+	if code != http.StatusOK {
+		// Get error message
+		var f map[string]string
+		err = json.Unmarshal(body, &f)
+		if err != nil {
+			return "", fmt.Errorf("unknown error from Grafana (%d)", code)
+		}
+		message, ok := f["message"]
+		if !ok {
+			return "", fmt.Errorf("unknown error from Grafana (%d)", code)
+		}
+		return "", fmt.Errorf("error from Grafana (%d): %s", code, message)
+	}
+
+	// Status OK, read dashboards info
+	var dashboards []map[string]interface{}
+	err = json.Unmarshal(body, &dashboards)
+	if err != nil {
+		return "", err
+	}
+	if len(dashboards) == 0 {
+		logger.Warningf("No Grafana dashboard found for pattern '%s'", name)
+		return "", nil
+	}
+	if len(dashboards) > 1 {
+		logger.Infof("Several Grafana dashboards found for pattern '%s', picking the first one", name)
+	}
+	dashPath, ok := dashboards[0]["url"]
+	if !ok {
+		logger.Warningf("URL field not found in Grafana dashboard for search pattern '%s'", name)
+		return "", nil
+	}
+	return dashPath.(string), nil
+}
+
+func findDashboard(url, searchPattern string, auth *extconfig.Auth) ([]byte, int, error) {
+	return httputil.HttpGet(url+"/api/search?query="+searchPattern, auth, time.Second*10)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,14 +1,13 @@
 package config
 
 import (
-	"github.com/kiali/k-charted/config/promconfig"
+	"github.com/kiali/k-charted/config/extconfig"
 	"github.com/kiali/k-charted/model"
 )
 
 type Config struct {
-	Prometheus      promconfig.PrometheusConfig `yaml:"prometheus"`
-	GlobalNamespace string                      `yaml:"global_namespace"`
-	Errorf          func(string, ...interface{})
-	Tracef          func(string, ...interface{})
+	Prometheus      extconfig.PrometheusConfig `yaml:"prometheus"`
+	Grafana         extconfig.GrafanaConfig    `yaml:"grafana"`
+	GlobalNamespace string                     `yaml:"global_namespace"`
 	PodsLoader      func(string, string) ([]model.Pod, error)
 }

--- a/config/extconfig/extconfig.go
+++ b/config/extconfig/extconfig.go
@@ -1,4 +1,4 @@
-package promconfig
+package extconfig
 
 // The valid auth strategies and values for cookie handling
 const (
@@ -12,6 +12,13 @@ const (
 type PrometheusConfig struct {
 	URL  string `yaml:"url"`
 	Auth Auth   `yaml:"auth"`
+}
+
+// GrafanaConfig describes configuration of the Grafana component
+type GrafanaConfig struct {
+	URL          string `yaml:"url"`
+	InClusterURL string `yaml:"in_cluster_url"`
+	Auth         Auth   `yaml:"auth"`
 }
 
 // Auth provides authentication data for external services

--- a/http/handler.go
+++ b/http/handler.go
@@ -10,53 +10,54 @@ import (
 
 	"github.com/kiali/k-charted/business"
 	"github.com/kiali/k-charted/config"
+	"github.com/kiali/k-charted/log"
 	"github.com/kiali/k-charted/model"
 )
 
 // DashboardHandler is the API handler to fetch runtime metrics to be displayed.
 // It expects "namespace" and "dashboard" to be provided as path params. Label filters can be provided as query params
 // (see also: ExtractDashboardQueryParams)
-func DashboardHandler(queryParams url.Values, pathParams map[string]string, w http.ResponseWriter, conf config.Config) {
+func DashboardHandler(queryParams url.Values, pathParams map[string]string, w http.ResponseWriter, conf config.Config, logger log.LogAdapter) {
 	namespace := pathParams["namespace"]
 	dashboardName := pathParams["dashboard"]
 
-	svc := business.NewDashboardsService(conf)
+	svc := business.NewDashboardsService(conf, logger)
 
 	params := model.DashboardQuery{Namespace: namespace}
 	err := ExtractDashboardQueryParams(queryParams, &params)
 	if err != nil {
-		respondWithError(conf, w, http.StatusBadRequest, err.Error())
+		respondWithError(svc.Logger, w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	dashboard, err := svc.GetDashboard(params, dashboardName)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			respondWithError(conf, w, http.StatusNotFound, err.Error())
+			respondWithError(svc.Logger, w, http.StatusNotFound, err.Error())
 		} else {
-			respondWithError(conf, w, http.StatusInternalServerError, err.Error())
+			respondWithError(svc.Logger, w, http.StatusInternalServerError, err.Error())
 		}
 		return
 	}
-	respondWithJSON(conf, w, http.StatusOK, dashboard)
+	respondWithJSON(svc.Logger, w, http.StatusOK, dashboard)
 }
 
 // SearchDashboardsHandler is the API handler to search for all available dashboards on pods
 // It expects "namespace" to be provided as path param. Label filters can be provided as query params
 // (see also: ExtractDashboardQueryParams)
-func SearchDashboardsHandler(queryParams url.Values, pathParams map[string]string, w http.ResponseWriter, conf config.Config) {
+func SearchDashboardsHandler(queryParams url.Values, pathParams map[string]string, w http.ResponseWriter, conf config.Config, logger log.LogAdapter) {
 	namespace := pathParams["namespace"]
 	labels := queryParams.Get("labelsFilters")
 
 	var runtimes []model.Runtime
-	svc := business.NewDashboardsService(conf)
+	svc := business.NewDashboardsService(conf, logger)
 	if conf.PodsLoader != nil {
 		pods, err := conf.PodsLoader(namespace, strings.Replace(labels, ":", "=", -1))
 		if err != nil {
 			if errors.IsNotFound(err) {
-				respondWithError(conf, w, http.StatusNotFound, err.Error())
+				respondWithError(svc.Logger, w, http.StatusNotFound, err.Error())
 			} else {
-				respondWithError(conf, w, http.StatusInternalServerError, err.Error())
+				respondWithError(svc.Logger, w, http.StatusInternalServerError, err.Error())
 			}
 			return
 		}
@@ -68,10 +69,10 @@ func SearchDashboardsHandler(queryParams url.Values, pathParams map[string]strin
 		runtimes = svc.DiscoverDashboards(namespace, labelsMap)
 	}
 
-	respondWithJSON(conf, w, http.StatusOK, runtimes)
+	respondWithJSON(svc.Logger, w, http.StatusOK, runtimes)
 }
 
-func respondWithJSON(conf config.Config, w http.ResponseWriter, code int, payload interface{}) {
+func respondWithJSON(logger log.SafeAdapter, w http.ResponseWriter, code int, payload interface{}) {
 	response, err := json.Marshal(payload)
 	if err != nil {
 		response, _ = json.Marshal(map[string]string{"error": err.Error()})
@@ -81,11 +82,11 @@ func respondWithJSON(conf config.Config, w http.ResponseWriter, code int, payloa
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_, err = w.Write(response)
-	if err != nil && conf.Errorf != nil {
-		conf.Errorf("could not write response: %v", err)
+	if err != nil {
+		logger.Errorf("could not write response: %v", err)
 	}
 }
 
-func respondWithError(conf config.Config, w http.ResponseWriter, code int, message string) {
-	respondWithJSON(conf, w, code, map[string]string{"error": message})
+func respondWithError(logger log.SafeAdapter, w http.ResponseWriter, code int, message string) {
+	respondWithJSON(logger, w, code, map[string]string{"error": message})
 }

--- a/kcharted.go
+++ b/kcharted.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/kiali/k-charted/business"
 	"github.com/kiali/k-charted/config"
+	"github.com/kiali/k-charted/log"
 )
 
 func main() {
 	fmt.Printf("Hello, Charts")
-	business.NewDashboardsService(config.Config{GlobalNamespace: "istio-system"})
+	business.NewDashboardsService(config.Config{GlobalNamespace: "istio-system"}, log.LogAdapter{})
 }

--- a/kubernetes/v1alpha1/spec.go
+++ b/kubernetes/v1alpha1/spec.go
@@ -33,10 +33,11 @@ type MonitoringDashboardsList struct {
 }
 
 type MonitoringDashboardSpec struct {
-	Title      string                    `json:"title"`
-	Runtime    string                    `json:"runtime"`
-	DiscoverOn string                    `json:"discoverOn"`
-	Items      []MonitoringDashboardItem `json:"items"`
+	Title         string                            `json:"title"`
+	Runtime       string                            `json:"runtime"`
+	DiscoverOn    string                            `json:"discoverOn"`
+	Items         []MonitoringDashboardItem         `json:"items"`
+	ExternalLinks []MonitoringDashboardExternalLink `json:"externalLinks"`
 }
 
 type MonitoringDashboardItem struct {
@@ -64,6 +65,20 @@ type MonitoringDashboardChart struct {
 type MonitoringDashboardAggregation struct {
 	Label       string `json:"label"`
 	DisplayName string `json:"displayName"`
+}
+
+type MonitoringDashboardExternalLink struct {
+	Type      string                                   `json:"type"`
+	Name      string                                   `json:"name"`
+	Variables MonitoringDashboardExternalLinkVariables `json:"variables"`
+}
+
+type MonitoringDashboardExternalLinkVariables struct {
+	Namespace string `json:"namespace,omitempty"`
+	App       string `json:"app,omitempty"`
+	Service   string `json:"service,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Workload  string `json:"workload,omitempty"`
 }
 
 // TODO: auto-generate the following deepcopy methods!

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,35 @@
+package log
+
+// LogAdapter is an adapter to any backed logger
+type LogAdapter struct {
+	Errorf   func(string, ...interface{})
+	Warningf func(string, ...interface{})
+	Infof    func(string, ...interface{})
+	Tracef   func(string, ...interface{})
+}
+
+type SafeAdapter = LogAdapter
+
+func noop(string, ...interface{}) {}
+
+func NewSafeAdapter(from LogAdapter) SafeAdapter {
+	safe := SafeAdapter{
+		Errorf:   noop,
+		Warningf: noop,
+		Infof:    noop,
+		Tracef:   noop,
+	}
+	if from.Errorf != nil {
+		safe.Errorf = from.Errorf
+	}
+	if from.Warningf != nil {
+		safe.Warningf = from.Warningf
+	}
+	if from.Infof != nil {
+		safe.Infof = from.Infof
+	}
+	if from.Tracef != nil {
+		safe.Tracef = from.Tracef
+	}
+	return safe
+}

--- a/model/dashboards.go
+++ b/model/dashboards.go
@@ -10,9 +10,10 @@ import (
 
 // MonitoringDashboard is the model representing custom monitoring dashboard, transformed from MonitoringDashboard k8s resource
 type MonitoringDashboard struct {
-	Title        string        `json:"title"`
-	Charts       []Chart       `json:"charts"`
-	Aggregations []Aggregation `json:"aggregations"`
+	Title         string         `json:"title"`
+	Charts        []Chart        `json:"charts"`
+	Aggregations  []Aggregation  `json:"aggregations"`
+	ExternalLinks []ExternalLink `json:"externalLinks"`
 }
 
 // Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard k8s resource
@@ -111,6 +112,13 @@ func ConvertAggregations(from v1alpha1.MonitoringDashboardSpec) []Aggregation {
 		return aggs[i].DisplayName < aggs[j].DisplayName
 	})
 	return aggs
+}
+
+// ExternalLink provides links to external dashboards (e.g. to Grafana)
+type ExternalLink struct {
+	URL       string                                            `json:"url"`
+	Name      string                                            `json:"name"`
+	Variables v1alpha1.MonitoringDashboardExternalLinkVariables `json:"variables"`
 }
 
 // Runtime holds the runtime title and associated dashboard template(s)

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -10,7 +10,8 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
-	"github.com/kiali/k-charted/config/promconfig"
+	"github.com/kiali/k-charted/config/extconfig"
+	"github.com/kiali/k-charted/httputil"
 )
 
 type ClientInterface interface {
@@ -30,9 +31,9 @@ type Client struct {
 
 // NewClient creates a new client to the Prometheus API.
 // It returns an error on any problem.
-func NewClient(cfg promconfig.PrometheusConfig) (*Client, error) {
+func NewClient(cfg extconfig.PrometheusConfig) (*Client, error) {
 	clientConfig := api.Config{Address: cfg.URL}
-	transportConfig, err := authTransport(&cfg.Auth, api.DefaultRoundTripper.(*http.Transport))
+	transportConfig, err := httputil.AuthTransport(&cfg.Auth, api.DefaultRoundTripper.(*http.Transport))
 	if err != nil {
 		return nil, err
 	}

--- a/web/common/types/Dashboards.ts
+++ b/web/common/types/Dashboards.ts
@@ -5,6 +5,7 @@ export interface DashboardModel {
   title: string;
   charts: ChartModel[];
   aggregations: AggregationModel[];
+  externalLinks: ExternalLink[];
 }
 
 export type SpanValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
@@ -25,4 +26,18 @@ export interface ChartModel {
 export interface AggregationModel {
   label: PromLabel;
   displayName: LabelDisplayName;
+}
+
+export interface ExternalLink {
+  url: string;
+  name: string;
+  variables: ExternalLinkVariables;
+}
+
+export interface ExternalLinkVariables {
+  app?: string;
+  namespace?: string;
+  service?: string;
+  version?: string;
+  workload?: string;
 }

--- a/web/pf3/src/index.ts
+++ b/web/pf3/src/index.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from './components/Dashboard';
-import { DashboardModel, ChartModel, AggregationModel } from '../../common/types/Dashboards';
+import { DashboardModel, ChartModel, AggregationModel, ExternalLink } from '../../common/types/Dashboards';
 import { LabelDisplayName, AllPromLabelsValues, PromLabel, SingleLabelValues } from '../../common/types/Labels';
 import { TimeSeries } from '../../common/types/Metrics';
 import { Aggregator, MetricsQuery, DashboardQuery } from '../../common/types/MetricsOptions';
@@ -10,6 +10,7 @@ export {
   DashboardModel,
   ChartModel,
   AggregationModel,
+  ExternalLink,
   LabelDisplayName,
   AllPromLabelsValues,
   PromLabel,

--- a/web/pf3/src/types/__mocks__/Dashboards.mock.ts
+++ b/web/pf3/src/types/__mocks__/Dashboards.mock.ts
@@ -14,12 +14,14 @@ export const generateRandomDashboard = (title: string, seed?: string): Dashboard
       generateRandomHistogramChart('Animal histogram'),
       generateRandomHistogramChart('Fruit histogram')
     ],
-    aggregations: []
+    aggregations: [],
+    externalLinks: []
   };
 };
 
 export const emptyDashboard: DashboardModel = {
   title: 'Empty dashboard',
   charts: [],
-  aggregations: []
+  aggregations: [],
+  externalLinks: []
 };

--- a/web/pf4/src/index.ts
+++ b/web/pf4/src/index.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from './components/Dashboard';
-import { DashboardModel, ChartModel, AggregationModel } from '../../common/types/Dashboards';
+import { DashboardModel, ChartModel, AggregationModel, ExternalLink } from '../../common/types/Dashboards';
 import { LabelDisplayName, AllPromLabelsValues, PromLabel, SingleLabelValues } from '../../common/types/Labels';
 import { TimeSeries } from '../../common/types/Metrics';
 import { Aggregator, MetricsQuery, DashboardQuery } from '../../common/types/MetricsOptions';
@@ -10,6 +10,7 @@ export {
   DashboardModel,
   ChartModel,
   AggregationModel,
+  ExternalLink,
   LabelDisplayName,
   AllPromLabelsValues,
   PromLabel,

--- a/web/pf4/src/types/__mocks__/Dashboards.mock.ts
+++ b/web/pf4/src/types/__mocks__/Dashboards.mock.ts
@@ -15,12 +15,14 @@ export const generateRandomDashboard = (title: string, seed?: string): Dashboard
       generateRandomMetricChart('Best animal++', ['dogs', 'cats', 'birds', 'stunning animal with very very long name that you\'ve never about', 'mermaids', 'escherichia coli', 'wohlfahrtiimonas', 'Chuck Norris'], 6),
       generateRandomMetricChart('Best fruit++', ['apples', 'oranges', 'bananas', 'peaches', 'peers', 'cherries', 'leetchies', 'pineapple'], 6),
     ],
-    aggregations: []
+    aggregations: [],
+    externalLinks: []
   };
 };
 
 export const emptyDashboard: DashboardModel = {
   title: 'Empty dashboard',
   charts: [],
-  aggregations: []
+  aggregations: [],
+  externalLinks: []
 };


### PR DESCRIPTION
- Add external links to CR spec
- Manage resolving grafana links, find out path through Grafana API
- Some refactoring on how logger is injected in k-charted
- On frontend, define model matching server model to be consumed (by kiali...)

Part of https://github.com/kiali/kiali/issues/1676