### PR TITLE
Improve logger with missing adapters

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -10,26 +10,25 @@ type LogAdapter struct {
 
 type SafeAdapter = LogAdapter
 
-func noop(string, ...interface{}) {}
-
 func NewSafeAdapter(from LogAdapter) SafeAdapter {
-	safe := SafeAdapter{
-		Errorf:   noop,
-		Warningf: noop,
-		Infof:    noop,
-		Tracef:   noop,
-	}
-	if from.Errorf != nil {
-		safe.Errorf = from.Errorf
-	}
-	if from.Warningf != nil {
-		safe.Warningf = from.Warningf
-	}
-	if from.Infof != nil {
-		safe.Infof = from.Infof
-	}
+	safe := SafeAdapter{}
+	// Default to noop
+	lastFunc := func(string, ...interface{}) {}
 	if from.Tracef != nil {
-		safe.Tracef = from.Tracef
+		lastFunc = from.Tracef
 	}
+	safe.Tracef = lastFunc
+	if from.Infof != nil {
+		lastFunc = from.Infof
+	}
+	safe.Infof = lastFunc
+	if from.Warningf != nil {
+		lastFunc = from.Warningf
+	}
+	safe.Warningf = lastFunc
+	if from.Errorf != nil {
+		lastFunc = from.Errorf
+	}
+	safe.Errorf = lastFunc
 	return safe
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,77 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var funcUsed string
+
+func errorf(msg string, args ...interface{}) {
+	funcUsed = "error"
+}
+
+func warnf(msg string, args ...interface{}) {
+	funcUsed = "warn"
+}
+
+func infof(msg string, args ...interface{}) {
+	funcUsed = "info"
+}
+
+func tracef(msg string, args ...interface{}) {
+	funcUsed = "trace"
+}
+
+func assertAndReset(t *testing.T, expected string) {
+	assert.Equal(t, expected, funcUsed)
+	funcUsed = ""
+}
+
+func TestNoLogger(t *testing.T) {
+	logger := NewSafeAdapter(LogAdapter{})
+
+	logger.Errorf("test")
+	assertAndReset(t, "")
+	logger.Warningf("test")
+	assertAndReset(t, "")
+	logger.Infof("test")
+	assertAndReset(t, "")
+	logger.Tracef("test")
+	assertAndReset(t, "")
+}
+
+func TestFullLogger(t *testing.T) {
+	logger := NewSafeAdapter(LogAdapter{
+		Errorf:   errorf,
+		Warningf: warnf,
+		Infof:    infof,
+		Tracef:   tracef,
+	})
+
+	logger.Errorf("test")
+	assertAndReset(t, "error")
+	logger.Warningf("test")
+	assertAndReset(t, "warn")
+	logger.Infof("test")
+	assertAndReset(t, "info")
+	logger.Tracef("test")
+	assertAndReset(t, "trace")
+}
+
+func TestPartialLogger(t *testing.T) {
+	logger := NewSafeAdapter(LogAdapter{
+		Errorf: errorf,
+		Infof:  infof,
+	})
+
+	logger.Errorf("test")
+	assertAndReset(t, "error")
+	logger.Warningf("test")
+	assertAndReset(t, "info")
+	logger.Infof("test")
+	assertAndReset(t, "info")
+	logger.Tracef("test")
+	assertAndReset(t, "")
+}


### PR DESCRIPTION
... so that logging at level X fallbacks to log at level x+1 if corresponding adapter is missing
e.g. log.Warningf fallbacks to log.Infof if Warningf callback is missing

Add tests