### PR TITLE
Handle unit scaling when input already scaled

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -190,6 +190,10 @@ func (in *DashboardsService) GetDashboard(params model.DashboardQuery, template 
 	for i, item := range dashboard.Spec.Items {
 		go func(idx int, chart v1alpha1.MonitoringDashboardChart) {
 			defer wg.Done()
+			unitScale := 1.0
+			if chart.UnitScale != 0.0 {
+				unitScale = chart.UnitScale
+			}
 			filledCharts[idx] = model.ConvertChart(chart)
 			if chart.DataType == v1alpha1.Raw {
 				aggregator := params.RawDataAggregator
@@ -197,13 +201,13 @@ func (in *DashboardsService) GetDashboard(params model.DashboardQuery, template 
 					aggregator = chart.Aggregator
 				}
 				metric := promClient.FetchRange(chart.MetricName, filters, grouping, aggregator, &params.MetricsQuery)
-				filledCharts[idx].Metric, filledCharts[idx].Error = in.convertMetric(metric, chart.MetricName)
+				filledCharts[idx].Metric, filledCharts[idx].Error = in.convertMetric(metric, unitScale, chart.MetricName)
 			} else if chart.DataType == v1alpha1.Rate {
 				metric := promClient.FetchRateRange(chart.MetricName, filters, grouping, &params.MetricsQuery)
-				filledCharts[idx].Metric, filledCharts[idx].Error = in.convertMetric(metric, chart.MetricName)
+				filledCharts[idx].Metric, filledCharts[idx].Error = in.convertMetric(metric, unitScale, chart.MetricName)
 			} else {
 				histo := promClient.FetchHistogramRange(chart.MetricName, filters, grouping, &params.MetricsQuery)
-				filledCharts[idx].Histogram, filledCharts[idx].Error = in.convertHistogram(histo, chart.MetricName)
+				filledCharts[idx].Histogram, filledCharts[idx].Error = in.convertHistogram(histo, unitScale, chart.MetricName)
 			}
 		}(i, item.Chart)
 	}
@@ -231,10 +235,10 @@ func (in *DashboardsService) GetDashboard(params model.DashboardQuery, template 
 	}, nil
 }
 
-func (in *DashboardsService) convertHistogram(from prometheus.Histogram, name string) (map[string][]*model.SampleStream, string) {
+func (in *DashboardsService) convertHistogram(from prometheus.Histogram, scale float64, name string) (map[string][]*model.SampleStream, string) {
 	stats := make(map[string][]*model.SampleStream, len(from))
 	for k, v := range from {
-		s, err := in.convertMetric(v, name+"/"+k)
+		s, err := in.convertMetric(v, scale, name+"/"+k)
 		if err != "" {
 			return nil, err
 		}
@@ -243,12 +247,12 @@ func (in *DashboardsService) convertHistogram(from prometheus.Histogram, name st
 	return stats, ""
 }
 
-func (in *DashboardsService) convertMetric(from prometheus.Metric, name string) ([]*model.SampleStream, string) {
+func (in *DashboardsService) convertMetric(from prometheus.Metric, scale float64, name string) ([]*model.SampleStream, string) {
 	if from.Err != nil {
 		in.Logger.Errorf("error in metric %s: %v", name, from.Err)
 		return []*model.SampleStream{}, from.Err.Error()
 	}
-	return model.ConvertMatrix(from.Matrix), ""
+	return model.ConvertMatrix(from.Matrix, scale), ""
 }
 
 // SearchExplicitDashboards will check annotations of all supplied pods to extract a unique list of dashboards

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -69,8 +69,8 @@ func TestGetDashboard(t *testing.T) {
 	assert.Equal("My chart 1_2", dashboard.Charts[1].Name)
 	assert.Nil(dashboard.Charts[0].Histogram)
 	assert.Nil(dashboard.Charts[1].Metric)
-	assert.Equal(float64(10), dashboard.Charts[0].Metric[0].Values[0].Value)
-	assert.Equal(float64(11), dashboard.Charts[1].Histogram["avg"][0].Values[0].Value)
+	assert.Equal(float64(100), dashboard.Charts[0].Metric[0].Values[0].Value)
+	assert.Equal(float64(110), dashboard.Charts[1].Histogram["avg"][0].Values[0].Value)
 }
 
 func TestGetDashboardFromKialiNamespace(t *testing.T) {
@@ -260,13 +260,13 @@ func TestConvertEmptyMetric(t *testing.T) {
 	var metric prometheus.Metric
 
 	// Make sure metric is never nil, but empty slice
-	res, err := in.convertMetric(metric, "foo")
+	res, err := in.convertMetric(metric, 0.0, "foo")
 	assert.Empty(err)
 	assert.NotNil(res)
 	assert.Len(res, 0)
 
 	metric.Err = errors.New("Some error")
-	res, err = in.convertMetric(metric, "foo")
+	res, err = in.convertMetric(metric, 0.0, "foo")
 	assert.Equal("Some error", err)
 	assert.NotNil(res)
 	assert.Len(res, 0)
@@ -278,7 +278,7 @@ func TestConvertEmptyHistogram(t *testing.T) {
 	var histo prometheus.Histogram
 
 	// An empty histogram gives an empty map
-	res, err := in.convertHistogram(histo, "foo")
+	res, err := in.convertHistogram(histo, 0.0, "foo")
 	assert.Empty(err)
 	assert.NotNil(res)
 	assert.Len(res, 0)
@@ -287,7 +287,7 @@ func TestConvertEmptyHistogram(t *testing.T) {
 	histo = make(prometheus.Histogram)
 	var metric prometheus.Metric
 	histo["0.99"] = metric
-	res, err = in.convertHistogram(histo, "foo")
+	res, err = in.convertHistogram(histo, 0.0, "foo")
 	assert.Empty(err)
 	assert.NotNil(res)
 	assert.Len(res, 1)
@@ -297,7 +297,7 @@ func TestConvertEmptyHistogram(t *testing.T) {
 	// Check with error (here, histogram is nil)
 	metric.Err = errors.New("Some error")
 	histo["0.99"] = metric
-	res, err = in.convertHistogram(histo, "foo")
+	res, err = in.convertHistogram(histo, 0.0, "foo")
 	assert.Equal("Some error", err)
 	assert.Nil(res)
 }

--- a/kubernetes/mock/mock.go
+++ b/kubernetes/mock/mock.go
@@ -30,6 +30,7 @@ func FakeChart(id, dataType string) v1alpha1.MonitoringDashboardChart {
 	return v1alpha1.MonitoringDashboardChart{
 		Name:       "My chart " + id,
 		Unit:       "s",
+		UnitScale:  10.0,
 		Spans:      6,
 		MetricName: "my_metric_" + id,
 		DataType:   dataType,

--- a/kubernetes/v1alpha1/spec.go
+++ b/kubernetes/v1alpha1/spec.go
@@ -51,7 +51,8 @@ type MonitoringDashboardItem struct {
 
 type MonitoringDashboardChart struct {
 	Name         string                           `json:"name"`
-	Unit         string                           `json:"unit"`
+	Unit         string                           `json:"unit"`      // Stands for the base unit (regardless its scale in datasource)
+	UnitScale    float64                          `json:"unitScale"` // Stands for the scale of the values in datasource, related to the base unit provided. E.g. unit: "seconds" and unitScale: 0.001 means that values in datasource are actually in milliseconds.
 	Spans        int                              `json:"spans"`
 	ChartType    *string                          `json:"chartType"`
 	Min          *int                             `json:"min"`

--- a/model/dashboards.go
+++ b/model/dashboards.go
@@ -29,10 +29,10 @@ type Chart struct {
 	Error     string                     `json:"error"`
 }
 
-func ConvertMatrix(from pmod.Matrix) []*SampleStream {
+func ConvertMatrix(from pmod.Matrix, scale float64) []*SampleStream {
 	series := make([]*SampleStream, len(from))
 	for i, s := range from {
-		series[i] = convertSampleStream(s)
+		series[i] = convertSampleStream(s, scale)
 	}
 	return series
 }
@@ -42,14 +42,14 @@ type SampleStream struct {
 	Values   []SamplePair      `json:"values"`
 }
 
-func convertSampleStream(from *pmod.SampleStream) *SampleStream {
+func convertSampleStream(from *pmod.SampleStream, scale float64) *SampleStream {
 	labelSet := make(map[string]string, len(from.Metric))
 	for k, v := range from.Metric {
 		labelSet[string(k)] = string(v)
 	}
 	values := make([]SamplePair, len(from.Values))
 	for i, v := range from.Values {
-		values[i] = convertSamplePair(&v)
+		values[i] = convertSamplePair(&v, scale)
 	}
 	return &SampleStream{
 		LabelSet: labelSet,
@@ -70,10 +70,10 @@ func (s SamplePair) MarshalJSON() ([]byte, error) {
 	}.MarshalJSON()
 }
 
-func convertSamplePair(from *pmod.SamplePair) SamplePair {
+func convertSamplePair(from *pmod.SamplePair, scale float64) SamplePair {
 	return SamplePair{
 		Timestamp: int64(from.Timestamp),
-		Value:     float64(from.Value),
+		Value:     scale * float64(from.Value),
 	}
 }
 

--- a/model/dashboards_test.go
+++ b/model/dashboards_test.go
@@ -87,7 +87,7 @@ func TestConvertEmptyMatrix(t *testing.T) {
 	var matrix pmod.Matrix
 
 	// Make sure matrices are never nil, but empty slices
-	res := ConvertMatrix(matrix)
+	res := ConvertMatrix(matrix, 0.0)
 	assert.NotNil(res)
 	assert.Len(res, 0)
 }


### PR DESCRIPTION
E.g. if values are expressed in milliseconds for a given metric, we need to define chart with:
unit: "seconds"
unitScale: 0.001

Unit stands for the *base* unit, regardless scale.

Closes https://github.com/kiali/kiali/issues/1715