### PR TITLE
Traces via k-charted

### DIFF
--- a/web/pf4/src/components/ChartWithLegend.stories.tsx
+++ b/web/pf4/src/components/ChartWithLegend.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { ChartScatter } from '@patternfly/react-charts';
+import { storiesOf } from '@storybook/react';
+
+import '@patternfly/react-core/dist/styles/base.css';
+import ChartWithLegend from './ChartWithLegend';
+import { VCLine } from '../types/VictoryChartInfo';
+
+const traces: VCLine = {
+  datapoints: [{
+    x: 0,
+    y: 62,
+    name: 'Trace 1',
+    unit: 'ms',
+    size: 8
+  }, {
+    x: 4,
+    y: 80,
+    name: 'Trace 2',
+    unit: 'ms',
+    size: 4
+  }, {
+    x: 5,
+    y: 83,
+    name: 'Trace 3',
+    unit: 'ms',
+    size: 4
+  }, {
+    x: 8,
+    y: 45,
+    name: 'Trace 4',
+    unit: 'ms',
+    size: 5
+  }, {
+    x: 16,
+    y: 152,
+    name: 'Trace 5',
+    unit: 'ms',
+    size: 10
+  }] as any,
+  legendItem: {
+    name: 'span duration'
+  } as any
+};
+
+storiesOf('ChartWithLegend', module)
+  .add('as scatter plots', () => {
+    return <ChartWithLegend data={[traces]} unit="ms" seriesComponent={(<ChartScatter/>)} />;
+  });

--- a/web/pf4/src/components/ChartWithLegend.tsx
+++ b/web/pf4/src/components/ChartWithLegend.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import { Chart, ChartGroup, ChartAxis, ChartScatter, ChartProps } from '@patternfly/react-charts';
+import { VictoryLegend, VictoryPortal, VictoryLabel } from 'victory';
+import { format as d3Format } from 'd3-format';
+
+import { getFormatter } from '../../../common/utils/formatter';
+import { VCLines } from '../types/VictoryChartInfo';
+import { VCOverlay } from '../types/Overlay';
+import { createContainer } from './Container';
+import { buildLegendInfo } from '../utils/victoryChartsUtils';
+
+type Props = {
+  data: VCLines;
+  seriesComponent: any;
+  unit: string;
+  chartHeight?: number;
+  groupOffset?: number;
+  fill?: boolean;
+  stroke?: boolean;
+  moreChartProps?: ChartProps;
+  overlay?: VCOverlay;
+};
+
+type State = {
+  width: number;
+  hiddenSeries: Set<number>;
+};
+
+class ChartWithLegend extends React.Component<Props, State> {
+  containerRef: React.RefObject<HTMLDivElement>;
+
+  constructor(props: Props) {
+    super(props);
+    this.containerRef = React.createRef<HTMLDivElement>();
+    this.state = { width: 0, hiddenSeries: new Set() };
+  }
+
+  handleResize = () => {
+    if (this.containerRef && this.containerRef.current) {
+      this.setState({ width: this.containerRef.current.clientWidth });
+    }
+  };
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+    });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  render() {
+    const scaleInfo = this.scaledAxisInfo(this.props.data);
+    const groupOffset = this.props.groupOffset || 0;
+
+    const dataWithOverlay = this.props.overlay ? this.props.data.concat(this.props.overlay.data) : this.props.data;
+    const overlayIdx = this.props.data.length;
+    const legend = buildLegendInfo(dataWithOverlay, this.state.width);
+    const height = 300 + legend.height;
+    const padding = { top: 10, bottom: 20, left: 40, right: 10 };
+    padding.bottom += legend.height;
+
+    const events = this.props.data.map((_, idx) => this.registerEvents(idx, 'serie-' + idx));
+    if (this.props.overlay) {
+      events.push(this.registerEvents(overlayIdx, 'overlay'));
+    }
+
+    return (
+      <div ref={this.containerRef}>
+        <Chart
+          height={height}
+          width={this.state.width}
+          padding={padding}
+          events={events}
+          containerComponent={createContainer()}
+          scale={{x: 'time'}}
+          {...this.props.moreChartProps}
+        >
+          <ChartGroup offset={groupOffset}>
+            {this.props.data.map((serie, idx) => {
+              if (this.state.hiddenSeries.has(idx)) {
+                return undefined;
+              }
+              return React.cloneElement(this.props.seriesComponent, {
+                key: 'serie-' + idx,
+                name: 'serie-' + idx,
+                data: serie.datapoints,
+                style: { data: { fill: this.props.fill ? serie.color : undefined, stroke: this.props.stroke ? serie.color : undefined }}
+              });
+            })}
+          </ChartGroup>
+          {this.props.overlay && !this.state.hiddenSeries.has(overlayIdx) && (
+            <ChartScatter key="overlay" name="overlay" data={this.props.overlay.data.datapoints} style={{ data: this.props.overlay.origin.dataStyle }} />
+          )}
+          <ChartAxis
+            tickCount={scaleInfo.count}
+            style={{ tickLabels: {fontSize: 12, padding: 2} }}
+          />
+          <ChartAxis
+            tickLabelComponent={<VictoryPortal><VictoryLabel/></VictoryPortal>}
+            dependentAxis={true}
+            tickFormat={getFormatter(d3Format, this.props.unit)}
+            style={{ tickLabels: {fontSize: 12, padding: 2} }}
+          />
+          <VictoryLegend
+            name={'serie-legend'}
+            data={dataWithOverlay.map((s, idx) => {
+              if (this.state.hiddenSeries.has(idx)) {
+                return { ...s.legendItem, symbol: { fill: '#72767b' } };
+              }
+              return s.legendItem;
+            })}
+            x={50}
+            y={height - legend.height}
+            height={legend.height}
+            width={this.state.width}
+            itemsPerRow={legend.itemsPerRow}
+          />
+        </Chart>
+      </div>
+    );
+  }
+
+  private registerEvents(idx: number, serieName: string) {
+    return {
+      childName: ['serie-legend'],
+      target: ['data', 'labels'],
+      eventKey: String(idx),
+      eventHandlers: {
+        onMouseOver: () => {
+          return [
+            {
+              childName: [serieName],
+              target: 'data',
+              eventKey: 'all',
+              mutation: props => {
+                return {
+                  style: {...props.style,  strokeWidth: 4, fillOpacity: 0.5}
+                };
+              }
+            }
+          ];
+        },
+        onMouseOut: () => {
+          return [
+            {
+              childName: [serieName],
+              target: 'data',
+              eventKey: 'all',
+              mutation: () => {
+                return null;
+              }
+            }
+          ];
+        },
+        onClick: () => {
+          return [
+            {
+              childName: [serieName],
+              target: 'data',
+              mutation: () => {
+                if (!this.state.hiddenSeries.delete(idx)) {
+                  // Was not already hidden => add to set
+                  this.state.hiddenSeries.add(idx);
+                }
+                this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+                return null;
+              }
+            },
+            {
+              childName: [serieName],
+              target: 'data',
+              eventKey: 'all',
+              mutation: () => null
+            }
+          ];
+        }
+      },
+    };
+  }
+
+  private scaledAxisInfo(data: VCLines) {
+    const ticks = Math.max(...(data.map(s => s.datapoints.length)));
+    if (this.state.width < 500) {
+      return {
+        count: Math.min(5, ticks),
+        format: '%H:%M'
+      };
+    } else if (this.state.width < 700) {
+      return {
+        count: Math.min(10, ticks),
+        format: '%H:%M'
+      };
+    }
+    return {
+      count: Math.min(15, ticks),
+      format: '%H:%M:%S'
+    };
+  }
+}
+
+export default ChartWithLegend;

--- a/web/pf4/src/components/Container.tsx
+++ b/web/pf4/src/components/Container.tsx
@@ -8,7 +8,7 @@ export const createContainer = () => {
   const tooltip = <ChartTooltip flyoutComponent={<CustomFlyout />} constrainToVisibleArea={true} />;
   return (
     <ChartVoronoiContainer
-      labels={obj => `${obj.datum.name}: ${getFormatter(d3Format, obj.datum.unit)(obj.datum.y)}`}
+      labels={obj => `${obj.datum.name}: ${getFormatter(d3Format, obj.datum.unit)(obj.datum.actualY || obj.datum.y)}`}
       labelComponent={tooltip}
       // We blacklist "parent" as a workaround to avoid the VictoryVoronoiContainer crashing.
       // See https://github.com/FormidableLabs/victory/issues/1355

--- a/web/pf4/src/components/Dashboard.tsx
+++ b/web/pf4/src/components/Dashboard.tsx
@@ -6,7 +6,8 @@ import { getTheme, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-
 
 import { AllPromLabelsValues } from '../../../common/types/Labels';
 import { DashboardModel, ChartModel } from '../../../common/types/Dashboards';
-import { getDataSupplier } from '../utils/victoryChartsUtils';
+import { getDataSupplier, toVCOverlay } from '../utils/victoryChartsUtils';
+import { Overlay, VCOverlay } from '../types/Overlay';
 import KChart from './KChart';
 
 const expandedChartContainerStyle = style({
@@ -25,6 +26,7 @@ type Props = {
   expandHandler: (expandedChart?: string) => void;
   labelPrettifier?: (key: string, value: string) => string;
   colors?: string[];
+  overlay?: Overlay;
 };
 
 type State = {
@@ -56,8 +58,9 @@ export class Dashboard extends React.Component<Props, State> {
   }
 
   renderMetrics() {
+    const overlay = this.props.overlay ? toVCOverlay(this.props.overlay) : undefined;
     return (
-      <Grid>{this.props.dashboard.charts.map(c => this.renderChartCard(c))}</Grid>
+      <Grid>{this.props.dashboard.charts.map(c => this.renderChartCard(c, overlay))}</Grid>
     );
   }
 
@@ -69,15 +72,15 @@ export class Dashboard extends React.Component<Props, State> {
     return undefined;
   }
 
-  private renderChartCard(chart: ChartModel) {
+  private renderChartCard(chart: ChartModel, overlay?: VCOverlay) {
     return (
       <GridItem span={chart.spans} key={chart.name}>
-        {this.renderChart(chart, () => this.expandHandler(chart.name))}
+        {this.renderChart(chart, () => this.expandHandler(chart.name), overlay)}
       </GridItem>
     );
   }
 
-  private renderChart(chart: ChartModel, expandHandler?: () => void) {
+  private renderChart(chart: ChartModel, expandHandler?: () => void, overlay?: VCOverlay) {
     const colors = this.props.colors || getTheme(ChartThemeColor.multi, ChartThemeVariant.default).chart.colorScale;
     const dataSupplier = getDataSupplier(chart, { values: this.props.labelValues, prettifier: this.props.labelPrettifier }, colors);
     return (
@@ -86,6 +89,7 @@ export class Dashboard extends React.Component<Props, State> {
         chart={chart}
         data={dataSupplier()}
         expandHandler={expandHandler}
+        overlay={overlay}
       />
     );
   }

--- a/web/pf4/src/components/KChart.stories.tsx
+++ b/web/pf4/src/components/KChart.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import KChart from './KChart';
-import { getDataSupplier } from '../utils/victoryChartsUtils';
-import { empty, error, generateRandomMetricChart, generateRandomHistogramChart, emptyLabels } from '../types/__mocks__/Charts.mock';
+import { getDataSupplier, toVCOverlay } from '../utils/victoryChartsUtils';
+import { empty, error, generateRandomMetricChart, generateRandomHistogramChart, generateRandomOverlay, emptyLabels } from '../types/__mocks__/Charts.mock';
 
 import '@patternfly/react-core/dist/styles/base.css';
 
@@ -36,6 +36,13 @@ storiesOf('PF4 KChart', module)
     metric.min = 20;
     metric.max = 100;
     return <KChart chart={metric} data={getDataSupplier(metric, emptyLabels, colors)!()} />;
+  })
+  .add('with overlay', () => {
+    reset();
+    const overlay = generateRandomOverlay();
+    return (
+      <KChart chart={metric} data={getDataSupplier(metric, emptyLabels, colors)!()} overlay={toVCOverlay(overlay)} />
+    );
   })
   .add('histogram', () => (
     <KChart chart={histogram} data={getDataSupplier(histogram, emptyLabels, colors)!()} />

--- a/web/pf4/src/components/KChart.tsx
+++ b/web/pf4/src/components/KChart.tsx
@@ -1,27 +1,19 @@
 import * as React from 'react';
 import { style } from 'typestyle';
 import { Button, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { Chart, ChartArea, ChartBar, ChartLine, ChartGroup, ChartAxis } from '@patternfly/react-charts';
+import { ChartArea, ChartBar, ChartLine } from '@patternfly/react-charts';
 import { ExpandArrowsAltIcon, InfoAltIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
-import { VictoryLegend, VictoryPortal, VictoryLabel } from 'victory';
-import { format as d3Format } from 'd3-format';
 
 import { ChartModel } from '../../../common/types/Dashboards';
-import { getFormatter } from '../../../common/utils/formatter';
-import { VCLines, VCLine } from '../types/VictoryChartInfo';
-import { createContainer } from './Container';
-import { buildLegendInfo } from '../utils/victoryChartsUtils';
+import { VCLines } from '../types/VictoryChartInfo';
+import { VCOverlay } from '../types/Overlay';
+import ChartWithLegend from './ChartWithLegend';
 
 type KChartProps = {
   chart: ChartModel;
   data: VCLines;
-  chartHeight?: number;
   expandHandler?: () => void;
-};
-
-type State = {
-  width: number;
-  hiddenSeries: Set<number>;
+  overlay?: VCOverlay;
 };
 
 const expandBlockStyle: React.CSSProperties = {
@@ -52,32 +44,7 @@ const emptyMetricsStyle = style({
   }
 });
 
-class KChart extends React.Component<KChartProps, State> {
-  containerRef: React.RefObject<HTMLDivElement>;
-
-  constructor(props: KChartProps) {
-    super(props);
-    this.containerRef = React.createRef<HTMLDivElement>();
-    this.state = { width: 0, hiddenSeries: new Set() };
-  }
-
-  handleResize = () => {
-    if (this.containerRef && this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
-    }
-  };
-
-  componentDidMount() {
-    setTimeout(() => {
-      this.handleResize();
-      window.addEventListener('resize', this.handleResize);
-    });
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
-  }
-
+class KChart extends React.Component<KChartProps, {}> {
   onExpandHandler = () => {
     this.props.expandHandler!();
   }
@@ -99,126 +66,39 @@ class KChart extends React.Component<KChartProps, State> {
       return this.renderEmpty();
     }
 
-    const scaleInfo = this.scaledAxisInfo(this.props.data);
-    const seriesBuilder =
-      (this.props.chart.chartType === 'area') ? (serie: VCLine, idx) => (<ChartArea key={'serie-' + idx} name={'serie-' + idx} data={serie.datapoints} style={{ data: { fill: serie.color } }} />) :
-      (this.props.chart.chartType === 'bar')  ? (serie: VCLine, idx) => (<ChartBar key={'serie-' + idx} name={'serie-' + idx} data={serie.datapoints} style={{ data: { fill: serie.color } }} />) :
-                                                (serie: VCLine, idx) => (<ChartLine key={'serie-' + idx} name={'serie-' + idx} data={serie.datapoints} style={{ data: { stroke: serie.color } }} />);
+    let fill = false;
+    let stroke = true;
+    let seriesComponent = (<ChartLine/>);
+    if (this.props.chart.chartType === 'area') {
+      fill = true;
+      stroke = false;
+      seriesComponent = (<ChartArea/>);
+    } else if (this.props.chart.chartType === 'bar') {
+      fill = true;
+      stroke = false;
+      seriesComponent = (<ChartBar/>);
+    }
+
     const groupOffset = this.props.chart.chartType === 'bar' ? 7 : 0;
     const minDomain = this.props.chart.min === undefined ? undefined : { y: this.props.chart.min };
     const maxDomain = this.props.chart.max === undefined ? undefined : { y: this.props.chart.max };
 
-    const legend = buildLegendInfo(this.props.data, this.state.width);
-    const height = 300 + legend.height;
-    const padding = { top: 10, bottom: 20, left: 40, right: 10 };
-    padding.bottom += legend.height;
-
-    const events = this.props.data.map((_, idx) => {
-      return {
-        childName: ['serie-legend'],
-        target: ['data', 'labels'],
-        eventKey: String(idx),
-        eventHandlers: {
-          onMouseOver: () => {
-            return [
-              {
-                childName: ['serie-' + idx],
-                target: 'data',
-                eventKey: 'all',
-                mutation: props => {
-                  return {
-                    style: {...props.style,  strokeWidth: 4, fillOpacity: 0.5}
-                  };
-                }
-              }
-            ];
-          },
-          onMouseOut: () => {
-            return [
-              {
-                childName: ['serie-' + idx],
-                target: 'data',
-                eventKey: 'all',
-                mutation: () => {
-                  return null;
-                }
-              }
-            ];
-          },
-          onClick: () => {
-            return [
-              {
-                childName: ['serie-' + idx],
-                target: 'data',
-                mutation: () => {
-                  if (!this.state.hiddenSeries.delete(idx)) {
-                    // Was not already hidden => add to set
-                    this.state.hiddenSeries.add(idx);
-                  }
-                  this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
-                  return null;
-                }
-              },
-              {
-                childName: ['serie-' + idx],
-                target: 'data',
-                eventKey: 'all',
-                mutation: () => null
-              }
-            ];
-          }
-        },
-      };
-    });
-
     return (
-      <div ref={this.containerRef}>
+      <>
         <TextContent>
           <Text component={TextVariants.h4} style={{textAlign: 'center'}}>{this.props.chart.name}</Text>
         </TextContent>
-        <Chart
-          height={height}
-          width={this.state.width}
-          padding={padding}
-          events={events}
-          containerComponent={createContainer()}
-          scale={{x: 'time'}}
-          minDomain={minDomain}
-          maxDomain={maxDomain}>
-          <ChartGroup offset={groupOffset}>
-            {this.props.data.map((serie, idx) => {
-              if (this.state.hiddenSeries.has(idx)) {
-                return undefined;
-              }
-              return seriesBuilder(serie, idx);
-            })}
-          </ChartGroup>
-          <ChartAxis
-            tickCount={scaleInfo.count}
-            style={{ tickLabels: {fontSize: 12, padding: 2} }}
-          />
-          <ChartAxis
-            tickLabelComponent={<VictoryPortal><VictoryLabel/></VictoryPortal>}
-            dependentAxis={true}
-            tickFormat={getFormatter(d3Format, this.props.chart.unit)}
-            style={{ tickLabels: {fontSize: 12, padding: 2} }}
-          />
-          <VictoryLegend
-            name={'serie-legend'}
-            data={this.props.data.map((s, idx) => {
-              if (this.state.hiddenSeries.has(idx)) {
-                return { ...s.legendItem, symbol: { fill: '#72767b' } };
-              }
-              return s.legendItem;
-            })}
-            x={50}
-            y={height - legend.height}
-            height={legend.height}
-            width={this.state.width}
-            itemsPerRow={legend.itemsPerRow}
-          />
-        </Chart>
-      </div>
+        <ChartWithLegend
+          data={this.props.data}
+          seriesComponent={seriesComponent}
+          fill={fill}
+          stroke={stroke}
+          groupOffset={groupOffset}
+          overlay={this.props.overlay}
+          unit={this.props.chart.unit}
+          moreChartProps={{ minDomain: minDomain, maxDomain: maxDomain }}
+        />
+      </>
     );
   }
 
@@ -254,25 +134,6 @@ class KChart extends React.Component<KChartProps, State> {
         </div>
       </div>
     );
-  }
-
-  private scaledAxisInfo(data: VCLines) {
-    const ticks = Math.max(...(data.map(s => s.datapoints.length)));
-    if (this.state.width < 500) {
-      return {
-        count: Math.min(5, ticks),
-        format: '%H:%M'
-      };
-    } else if (this.state.width < 700) {
-      return {
-        count: Math.min(10, ticks),
-        format: '%H:%M'
-      };
-    }
-    return {
-      count: Math.min(15, ticks),
-      format: '%H:%M:%S'
-    };
   }
 }
 

--- a/web/pf4/src/types/Overlay.ts
+++ b/web/pf4/src/types/Overlay.ts
@@ -1,0 +1,17 @@
+import { Datapoint } from '../../../common/types/Metrics';
+import { VCLine } from './VictoryChartInfo';
+
+export type Overlay = {
+  datapoints: Datapoint[],
+  title: string,
+  unit: string,
+  dataStyle: any, // see "data" in https://formidable.com/open-source/victory/docs/common-props/#style
+  color: string,
+  symbol: string,
+  size: number
+};
+
+export type VCOverlay = {
+  data: VCLine,
+  origin: Overlay
+};

--- a/web/pf4/src/types/VictoryChartInfo.ts
+++ b/web/pf4/src/types/VictoryChartInfo.ts
@@ -11,7 +11,7 @@ export type VCDataPoint = {
 
 export type LegendItem = {
   name: string;
-  symbol?: { fill?: string; type?: string };
+  symbol: { fill: string; type?: string };
 };
 
 export type VCLine = {

--- a/web/pf4/src/types/__mocks__/Charts.mock.ts
+++ b/web/pf4/src/types/__mocks__/Charts.mock.ts
@@ -85,9 +85,9 @@ export const generateRandomHistogramChart = (title: string, spans: SpanValue, se
 
 export const generateRandomOverlay = (): Overlay => {
   return {
-    datapoints: genSingle(0, 50),
+    datapoints: genSingle(0, 50).map(pair => [pair[0], pair[1] / 100]),
     title: 'Span duration',
-    unit: 'ms',
+    unit: 'seconds',
     dataStyle: { fill: 'pink' },
     color: 'pink',
     symbol: 'star',

--- a/web/pf4/src/types/__mocks__/Charts.mock.ts
+++ b/web/pf4/src/types/__mocks__/Charts.mock.ts
@@ -2,6 +2,7 @@ import { ChartModel, SpanValue } from '../../../../common/types/Dashboards';
 import { TimeSeries } from '../../../../common/types/Metrics';
 import seedrandom from 'seedrandom';
 import { LabelsInfo } from '../../../../common/utils/timeSeriesUtils';
+import { Overlay } from '../Overlay';
 
 const t0 = 1556802000;
 const increment = 60;
@@ -79,6 +80,18 @@ export const generateRandomHistogramChart = (title: string, spans: SpanValue, se
     unit: 'bitrate',
     spans: spans,
     histogram: histo
+  };
+};
+
+export const generateRandomOverlay = (): Overlay => {
+  return {
+    datapoints: genSingle(0, 50),
+    title: 'Span duration',
+    unit: 'ms',
+    dataStyle: { fill: 'pink' },
+    color: 'pink',
+    symbol: 'star',
+    size: 15
   };
 };
 


### PR DESCRIPTION
- Add ability to display a custom overlay over kchart, as scatter plots
- Add ability to create charts without k-charted models / monitoringdashboard CRD => expose a new component ChartWithLegend for that
- Some refactoring to lighten the KChart component (now using that new ChartWithLegend)
- New stories: one for ChartWithLegend (simulating traces), another for the overlay

- Draw another axis and normalize values (see https://formidable.com/open-source/victory/gallery/multiple-dependent-axes )

Closes https://github.com/kiali/kiali/issues/1939