### PR TITLE
Overlays: some refactoring to allow more manipulation from caller

### DIFF
--- a/web/pf4/src/components/ChartWithLegend.stories.tsx
+++ b/web/pf4/src/components/ChartWithLegend.stories.tsx
@@ -9,33 +9,33 @@ import { VCLine } from '../types/VictoryChartInfo';
 const traces: VCLine = {
   datapoints: [{
     x: 0,
-    y: 62,
+    y: 0.62,
     name: 'Trace 1',
-    unit: 'ms',
+    unit: 'seconds',
     size: 8
   }, {
     x: 4,
-    y: 80,
+    y: 0.80,
     name: 'Trace 2',
-    unit: 'ms',
+    unit: 'seconds',
     size: 4
   }, {
     x: 5,
-    y: 83,
+    y: 0.83,
     name: 'Trace 3',
-    unit: 'ms',
+    unit: 'seconds',
     size: 4
   }, {
     x: 8,
-    y: 45,
+    y: 0.45,
     name: 'Trace 4',
-    unit: 'ms',
+    unit: 'seconds',
     size: 5
   }, {
     x: 16,
-    y: 152,
+    y: 0.152,
     name: 'Trace 5',
-    unit: 'ms',
+    unit: 'seconds',
     size: 10
   }] as any,
   legendItem: {
@@ -45,5 +45,5 @@ const traces: VCLine = {
 
 storiesOf('ChartWithLegend', module)
   .add('as scatter plots', () => {
-    return <ChartWithLegend data={[traces]} unit="ms" seriesComponent={(<ChartScatter/>)} />;
+    return <ChartWithLegend data={[traces]} unit="seconds" seriesComponent={(<ChartScatter/>)} onClick={dp => alert(`${dp.name}: [${dp.x}, ${dp.y}]`)} />;
   });

--- a/web/pf4/src/components/ChartWithLegend.tsx
+++ b/web/pf4/src/components/ChartWithLegend.tsx
@@ -19,6 +19,7 @@ type Props = {
   stroke?: boolean;
   moreChartProps?: ChartProps;
   overlay?: Overlay;
+  onClick?: (datum: any) => void;
 };
 
 type State = {
@@ -79,6 +80,22 @@ class ChartWithLegend extends React.Component<Props, State> {
         overlayFactor = mainMax / overlayMax;
       }
     }
+    const dataEvents: any[] = [];
+    if (this.props.onClick) {
+      dataEvents.push({
+        target: 'data',
+        eventHandlers: {
+          onClick: (event, target) => {
+            const pos = event.clientX - padding.left;
+            const size = this.state.width - padding.left - padding.right;
+            const ratio = pos / size;
+            const idx = Math.floor(ratio * target.data.length);
+            this.props.onClick!(target.data[idx]);
+            return [];
+          }
+        }
+      });
+    }
 
     return (
       <div ref={this.containerRef}>
@@ -100,12 +117,13 @@ class ChartWithLegend extends React.Component<Props, State> {
                 key: 'serie-' + idx,
                 name: 'serie-' + idx,
                 data: serie.datapoints,
+                events: dataEvents,
                 style: { data: { fill: this.props.fill ? serie.color : undefined, stroke: this.props.stroke ? serie.color : undefined }}
               });
             })}
           </ChartGroup>
           {showOverlay && (
-            <ChartScatter key="overlay" name="overlay" data={this.normalizeOverlay(overlayFactor)} style={{ data: this.props.overlay!.info.dataStyle }} />
+            <ChartScatter key="overlay" name="overlay" data={this.normalizeOverlay(overlayFactor)} style={{ data: this.props.overlay!.info.dataStyle }} events={dataEvents} />
           )}
           <ChartAxis
             tickCount={scaleInfo.count}

--- a/web/pf4/src/components/Dashboard.stories.tsx
+++ b/web/pf4/src/components/Dashboard.stories.tsx
@@ -10,7 +10,11 @@ const labels = new Map([['color', { 'green': true, 'orange': true, 'yellow': tru
 
 storiesOf('PF4 Dashboard', module)
   .add('with data', () => (
-    <Dashboard dashboard={generateRandomDashboard('Dashboard with data', 'dashboard-seed')} labelValues={labels} expandHandler={() => {}} />
+    <Dashboard
+      dashboard={generateRandomDashboard('Dashboard with data', 'dashboard-seed')}
+      labelValues={labels}
+      expandHandler={() => {}}
+    />
   ))
   .add('with gold theme', () => {
     const colors = getTheme(ChartThemeColor.gold, ChartThemeVariant.dark).chart.colorScale;

--- a/web/pf4/src/components/Dashboard.stories.tsx
+++ b/web/pf4/src/components/Dashboard.stories.tsx
@@ -14,6 +14,7 @@ storiesOf('PF4 Dashboard', module)
       dashboard={generateRandomDashboard('Dashboard with data', 'dashboard-seed')}
       labelValues={labels}
       expandHandler={() => {}}
+      onClick={(chart, dp) => alert(`${chart.name} - ${dp.name}: [${dp.x}, ${dp.y}]`)}
     />
   ))
   .add('with gold theme', () => {

--- a/web/pf4/src/components/Dashboard.tsx
+++ b/web/pf4/src/components/Dashboard.tsx
@@ -6,8 +6,8 @@ import { getTheme, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-
 
 import { AllPromLabelsValues } from '../../../common/types/Labels';
 import { DashboardModel, ChartModel } from '../../../common/types/Dashboards';
-import { getDataSupplier, toVCOverlay } from '../utils/victoryChartsUtils';
-import { Overlay, VCOverlay } from '../types/Overlay';
+import { getDataSupplier } from '../utils/victoryChartsUtils';
+import { Overlay } from '../types/Overlay';
 import KChart from './KChart';
 
 const expandedChartContainerStyle = style({
@@ -58,9 +58,8 @@ export class Dashboard extends React.Component<Props, State> {
   }
 
   renderMetrics() {
-    const overlay = this.props.overlay ? toVCOverlay(this.props.overlay) : undefined;
     return (
-      <Grid>{this.props.dashboard.charts.map(c => this.renderChartCard(c, overlay))}</Grid>
+      <Grid>{this.props.dashboard.charts.map(c => this.renderChartCard(c))}</Grid>
     );
   }
 
@@ -72,15 +71,15 @@ export class Dashboard extends React.Component<Props, State> {
     return undefined;
   }
 
-  private renderChartCard(chart: ChartModel, overlay?: VCOverlay) {
+  private renderChartCard(chart: ChartModel) {
     return (
       <GridItem span={chart.spans} key={chart.name}>
-        {this.renderChart(chart, () => this.expandHandler(chart.name), overlay)}
+        {this.renderChart(chart, () => this.expandHandler(chart.name))}
       </GridItem>
     );
   }
 
-  private renderChart(chart: ChartModel, expandHandler?: () => void, overlay?: VCOverlay) {
+  private renderChart(chart: ChartModel, expandHandler?: () => void) {
     const colors = this.props.colors || getTheme(ChartThemeColor.multi, ChartThemeVariant.default).chart.colorScale;
     const dataSupplier = getDataSupplier(chart, { values: this.props.labelValues, prettifier: this.props.labelPrettifier }, colors);
     return (
@@ -89,7 +88,7 @@ export class Dashboard extends React.Component<Props, State> {
         chart={chart}
         data={dataSupplier()}
         expandHandler={expandHandler}
-        overlay={overlay}
+        overlay={this.props.overlay}
       />
     );
   }

--- a/web/pf4/src/components/Dashboard.tsx
+++ b/web/pf4/src/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import { DashboardModel, ChartModel } from '../../../common/types/Dashboards';
 import { getDataSupplier } from '../utils/victoryChartsUtils';
 import { Overlay } from '../types/Overlay';
 import KChart from './KChart';
+import { VCDataPoint } from '../types/VictoryChartInfo';
 
 const expandedChartContainerStyle = style({
   height: 'calc(100vh - 248px)'
@@ -25,7 +26,7 @@ type Props = {
   expandedChart?: string;
   expandHandler: (expandedChart?: string) => void;
   labelPrettifier?: (key: string, value: string) => string;
-  onClick?: (chart: ChartModel, datum: any) => void;
+  onClick?: (chart: ChartModel, datum: VCDataPoint) => void;
   colors?: string[];
   overlay?: Overlay;
 };
@@ -83,9 +84,9 @@ export class Dashboard extends React.Component<Props, State> {
   private renderChart(chart: ChartModel, expandHandler?: () => void) {
     const colors = this.props.colors || getTheme(ChartThemeColor.multi, ChartThemeVariant.default).chart.colorScale;
     const dataSupplier = getDataSupplier(chart, { values: this.props.labelValues, prettifier: this.props.labelPrettifier }, colors);
-    let onClick: ((datum: any) => void) | undefined = undefined;
+    let onClick: ((datum: VCDataPoint) => void) | undefined = undefined;
     if (this.props.onClick) {
-      onClick = (datum: any) => this.props.onClick!(chart, datum);
+      onClick = (datum: VCDataPoint) => this.props.onClick!(chart, datum);
     }
     return (
       <KChart

--- a/web/pf4/src/components/Dashboard.tsx
+++ b/web/pf4/src/components/Dashboard.tsx
@@ -25,6 +25,7 @@ type Props = {
   expandedChart?: string;
   expandHandler: (expandedChart?: string) => void;
   labelPrettifier?: (key: string, value: string) => string;
+  onClick?: (chart: ChartModel, datum: any) => void;
   colors?: string[];
   overlay?: Overlay;
 };
@@ -82,6 +83,10 @@ export class Dashboard extends React.Component<Props, State> {
   private renderChart(chart: ChartModel, expandHandler?: () => void) {
     const colors = this.props.colors || getTheme(ChartThemeColor.multi, ChartThemeVariant.default).chart.colorScale;
     const dataSupplier = getDataSupplier(chart, { values: this.props.labelValues, prettifier: this.props.labelPrettifier }, colors);
+    let onClick: ((datum: any) => void) | undefined = undefined;
+    if (this.props.onClick) {
+      onClick = (datum: any) => this.props.onClick!(chart, datum);
+    }
     return (
       <KChart
         key={chart.name}
@@ -89,6 +94,7 @@ export class Dashboard extends React.Component<Props, State> {
         data={dataSupplier()}
         expandHandler={expandHandler}
         overlay={this.props.overlay}
+        onClick={onClick}
       />
     );
   }

--- a/web/pf4/src/components/KChart.stories.tsx
+++ b/web/pf4/src/components/KChart.stories.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import KChart from './KChart';
-import { getDataSupplier, toVCOverlay } from '../utils/victoryChartsUtils';
-import { empty, error, generateRandomMetricChart, generateRandomHistogramChart, generateRandomOverlay, emptyLabels } from '../types/__mocks__/Charts.mock';
+import { getDataSupplier, toOverlay, toVCLine, toVCDatapoints } from '../utils/victoryChartsUtils';
+import { empty, error, generateRandomMetricChart, generateRandomHistogramChart, generateRandomForOverlay, emptyLabels } from '../types/__mocks__/Charts.mock';
 
 import '@patternfly/react-core/dist/styles/base.css';
+import { OverlayInfo } from '../types/Overlay';
 
 const metric = generateRandomMetricChart('Random metric chart', ['dogs', 'cats', 'birds'], 12, 'kchart-seed');
 const histogram = generateRandomHistogramChart('Random histogram chart', 12, 'kchart-histo-seed');
@@ -39,9 +40,17 @@ storiesOf('PF4 KChart', module)
   })
   .add('with overlay', () => {
     reset();
-    const overlay = generateRandomOverlay();
+    const info: OverlayInfo = {
+      title: 'Span duration',
+      unit: 'seconds',
+      dataStyle: { fill: 'pink' },
+      color: 'pink',
+      symbol: 'star',
+      size: 15
+    };
+    const dps = toVCDatapoints(generateRandomForOverlay(), info.title);
     return (
-      <KChart chart={metric} data={getDataSupplier(metric, emptyLabels, colors)!()} overlay={toVCOverlay(overlay)} />
+      <KChart chart={metric} data={getDataSupplier(metric, emptyLabels, colors)!()} overlay={toOverlay(info, dps)} />
     );
   })
   .add('histogram', () => (

--- a/web/pf4/src/components/KChart.tsx
+++ b/web/pf4/src/components/KChart.tsx
@@ -6,14 +6,14 @@ import { ExpandArrowsAltIcon, InfoAltIcon, ErrorCircleOIcon } from '@patternfly/
 
 import { ChartModel } from '../../../common/types/Dashboards';
 import { VCLines } from '../types/VictoryChartInfo';
-import { VCOverlay } from '../types/Overlay';
+import { Overlay } from '../types/Overlay';
 import ChartWithLegend from './ChartWithLegend';
 
 type KChartProps = {
   chart: ChartModel;
   data: VCLines;
   expandHandler?: () => void;
-  overlay?: VCOverlay;
+  overlay?: Overlay;
 };
 
 const expandBlockStyle: React.CSSProperties = {

--- a/web/pf4/src/components/KChart.tsx
+++ b/web/pf4/src/components/KChart.tsx
@@ -5,7 +5,7 @@ import { ChartArea, ChartBar, ChartLine } from '@patternfly/react-charts';
 import { ExpandArrowsAltIcon, InfoAltIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
 
 import { ChartModel } from '../../../common/types/Dashboards';
-import { VCLines } from '../types/VictoryChartInfo';
+import { VCLines, VCDataPoint } from '../types/VictoryChartInfo';
 import { Overlay } from '../types/Overlay';
 import ChartWithLegend from './ChartWithLegend';
 
@@ -13,7 +13,7 @@ type KChartProps = {
   chart: ChartModel;
   data: VCLines;
   expandHandler?: () => void;
-  onClick?: (datum: any) => void;
+  onClick?: (datum: VCDataPoint) => void;
   overlay?: Overlay;
 };
 

--- a/web/pf4/src/components/KChart.tsx
+++ b/web/pf4/src/components/KChart.tsx
@@ -13,6 +13,7 @@ type KChartProps = {
   chart: ChartModel;
   data: VCLines;
   expandHandler?: () => void;
+  onClick?: (datum: any) => void;
   overlay?: Overlay;
 };
 
@@ -97,6 +98,7 @@ class KChart extends React.Component<KChartProps, {}> {
           overlay={this.props.overlay}
           unit={this.props.chart.unit}
           moreChartProps={{ minDomain: minDomain, maxDomain: maxDomain }}
+          onClick={this.props.onClick}
         />
       </>
     );

--- a/web/pf4/src/index.ts
+++ b/web/pf4/src/index.ts
@@ -4,6 +4,8 @@ import { LabelDisplayName, AllPromLabelsValues, PromLabel, SingleLabelValues } f
 import { TimeSeries } from '../../common/types/Metrics';
 import { Aggregator, MetricsQuery, DashboardQuery } from '../../common/types/MetricsOptions';
 import { DashboardRef, Runtime } from '../../common/types/Runtimes';
+import { toVCDatapoints, toVCLine, toOverlay } from './utils/victoryChartsUtils';
+import { Overlay, OverlayInfo } from './types/Overlay';
 
 export {
   Dashboard,
@@ -20,5 +22,10 @@ export {
   MetricsQuery,
   DashboardQuery,
   DashboardRef,
-  Runtime
+  Runtime,
+  toVCDatapoints,
+  toVCLine,
+  toOverlay,
+  Overlay,
+  OverlayInfo
 };

--- a/web/pf4/src/types/Overlay.ts
+++ b/web/pf4/src/types/Overlay.ts
@@ -1,8 +1,6 @@
-import { Datapoint } from '../../../common/types/Metrics';
 import { VCLine } from './VictoryChartInfo';
 
-export type Overlay = {
-  datapoints: Datapoint[],
+export type OverlayInfo = {
   title: string,
   unit: string,
   dataStyle: any, // see "data" in https://formidable.com/open-source/victory/docs/common-props/#style
@@ -11,7 +9,7 @@ export type Overlay = {
   size: number
 };
 
-export type VCOverlay = {
-  data: VCLine,
-  origin: Overlay
+export type Overlay = {
+  vcLine: VCLine,
+  info: OverlayInfo
 };

--- a/web/pf4/src/types/__mocks__/Charts.mock.ts
+++ b/web/pf4/src/types/__mocks__/Charts.mock.ts
@@ -1,8 +1,7 @@
 import { ChartModel, SpanValue } from '../../../../common/types/Dashboards';
-import { TimeSeries } from '../../../../common/types/Metrics';
+import { TimeSeries, Datapoint } from '../../../../common/types/Metrics';
 import seedrandom from 'seedrandom';
 import { LabelsInfo } from '../../../../common/utils/timeSeriesUtils';
-import { Overlay } from '../Overlay';
 
 const t0 = 1556802000;
 const increment = 60;
@@ -83,16 +82,8 @@ export const generateRandomHistogramChart = (title: string, spans: SpanValue, se
   };
 };
 
-export const generateRandomOverlay = (): Overlay => {
-  return {
-    datapoints: genSingle(0, 50).map(pair => [pair[0], pair[1] / 100]),
-    title: 'Span duration',
-    unit: 'seconds',
-    dataStyle: { fill: 'pink' },
-    color: 'pink',
-    symbol: 'star',
-    size: 15
-  };
+export const generateRandomForOverlay = (): Datapoint[] => {
+  return genSingle(0, 50).map(pair => [pair[0], pair[1] / 100]);
 };
 
 export const empty: ChartModel = {


### PR DESCRIPTION
- Caller can now provide list of datapoints in victory format
- Expose more classes and methods
- Overlays come hidden at init
- There's now an onclick hook so that caller can interact more deeply with the charts

Part of https://github.com/kiali/kiali/issues/1854