### PR TITLE
Never show 2nd axis when overlay is not displayed

### DIFF
--- a/web/pf4/src/components/ChartWithLegend.tsx
+++ b/web/pf4/src/components/ChartWithLegend.tsx
@@ -71,7 +71,7 @@ class ChartWithLegend extends React.Component<Props, State> {
 
     const events = this.props.data.map((_, idx) => this.registerEvents(idx, 'serie-' + idx));
     let overlayFactor = 1.0;
-    let useSecondAxis = this.props.overlay !== undefined;
+    let useSecondAxis = showOverlay;
     if (this.props.overlay) {
       events.push(this.registerEvents(overlayIdx, 'overlay'));
       // Normalization for y-axis display to match y-axis domain of the main data


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2083

**Before**:
![Capture d’écran de 2020-01-22 13-39-14](https://user-images.githubusercontent.com/2153442/72895039-dfb85680-3d1c-11ea-948a-9147db389fba.png)

*second axis was visible even with overlay hidden*

**After:**
![Capture d’écran de 2020-01-22 13-38-43](https://user-images.githubusercontent.com/2153442/72895035-dd55fc80-3d1c-11ea-9b0f-1c09f6216b2e.png)

*second axis is hidden when overlay hidden*
