### PR TITLE
Chart legends: do not use index to store hidden series

### DIFF
--- a/web/pf4/src/components/ChartWithLegend.stories.tsx
+++ b/web/pf4/src/components/ChartWithLegend.stories.tsx
@@ -33,7 +33,7 @@ const tracesXAsDatesBis = {
       color: 'lightblue'
     };
   }),
-  legendItem: makeLegend('span duration', 'lightblue')
+  legendItem: makeLegend('span duration 2', 'lightblue')
 };
 
 const crossing: VCLines = [

--- a/web/pf4/src/components/ChartWithLegend.tsx
+++ b/web/pf4/src/components/ChartWithLegend.tsx
@@ -4,7 +4,7 @@ import { VictoryLegend, VictoryPortal, VictoryLabel } from 'victory';
 import { format as d3Format } from 'd3-format';
 
 import { getFormatter } from '../../../common/utils/formatter';
-import { VCLines, VCDataPoint } from '../types/VictoryChartInfo';
+import { VCLines, VCDataPoint, LegendItem } from '../types/VictoryChartInfo';
 import { Overlay } from '../types/Overlay';
 import { newBrushVoronoiContainer, BrushHandlers } from './Container';
 import { buildLegendInfo, findClosestDatapoint } from '../utils/victoryChartsUtils';
@@ -27,8 +27,10 @@ type Props = {
 
 type State = {
   width: number;
-  hiddenSeries: Set<number>;
+  hiddenSeries: Set<string>;
 };
+
+const overlayName = 'overlay';
 
 class ChartWithLegend extends React.Component<Props, State> {
   containerRef: React.RefObject<HTMLDivElement>;
@@ -36,8 +38,7 @@ class ChartWithLegend extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.containerRef = React.createRef<HTMLDivElement>();
-    // Hidden series is initialized with the overlay index ( = data length )
-    this.state = { width: 0, hiddenSeries: new Set([props.data.length]) };
+    this.state = { width: 0, hiddenSeries: new Set([overlayName]) };
   }
 
   handleResize = () => {
@@ -61,23 +62,23 @@ class ChartWithLegend extends React.Component<Props, State> {
     const scaleInfo = this.scaledAxisInfo(this.props.data);
     const groupOffset = this.props.groupOffset || 0;
 
-    const dataWithOverlay = this.props.overlay ? this.props.data.concat(this.props.overlay.vcLine) : this.props.data;
+    const legendData = this.buildLegendData();
+    const legend = buildLegendInfo(legendData, this.state.width);
     const overlayIdx = this.props.data.length;
-    const showOverlay = this.props.overlay && !this.state.hiddenSeries.has(overlayIdx);
+    const showOverlay = this.props.overlay && !this.state.hiddenSeries.has(overlayName);
     const overlayRightPadding = showOverlay ? 30 : 0;
 
-    const legend = buildLegendInfo(dataWithOverlay, this.state.width);
     const height = (this.props.chartHeight || 300) + legend.height;
     const padding = { top: 10, bottom: 20, left: 40, right: 10 + overlayRightPadding };
     padding.bottom += legend.height;
 
     const events: VCEvent[] = [];
-    this.props.data.forEach((_, idx) => this.registerEvents(events, idx, 'serie-' + idx));
+    this.props.data.forEach((s, idx) => this.registerEvents(events, idx, 'serie-' + idx, s.legendItem.name));
     let useSecondAxis = showOverlay;
     let normalizedOverlay: VCDataPoint[] = [];
     let overlayFactor = 1.0;
     if (this.props.overlay) {
-      this.registerEvents(events, overlayIdx, 'overlay');
+      this.registerEvents(events, overlayIdx, overlayName, overlayName);
       // Normalization for y-axis display to match y-axis domain of the main data
       // (see https://formidable.com/open-source/victory/gallery/multiple-dependent-axes/)
       const mainMax = Math.max(...this.props.data.map(line => Math.max(...line.datapoints.map(d => d.y))));
@@ -137,11 +138,11 @@ class ChartWithLegend extends React.Component<Props, State> {
           {...this.props.moreChartProps}
         >
           {showOverlay && (
-            <ChartScatter key="overlay" name="overlay" data={normalizedOverlay} style={{ data: this.props.overlay!.info.dataStyle }} events={dataEvents} />
+            <ChartScatter key="overlay" name={overlayName} data={normalizedOverlay} style={{ data: this.props.overlay!.info.dataStyle }} events={dataEvents} />
           )}
           <ChartGroup offset={groupOffset}>
             {this.props.data.map((serie, idx) => {
-              if (this.state.hiddenSeries.has(idx)) {
+              if (this.state.hiddenSeries.has(serie.legendItem.name)) {
                 return undefined;
               }
               return React.cloneElement(this.props.seriesComponent, {
@@ -177,12 +178,7 @@ class ChartWithLegend extends React.Component<Props, State> {
           )}
           <VictoryLegend
             name={'serie-legend'}
-            data={dataWithOverlay.map((s, idx) => {
-              if (this.state.hiddenSeries.has(idx)) {
-                return { ...s.legendItem, symbol: { ...s.legendItem.symbol, fill: '#72767b' } };
-              }
-              return s.legendItem;
-            })}
+            data={legendData}
             x={50}
             y={height - legend.height}
             height={legend.height}
@@ -198,20 +194,37 @@ class ChartWithLegend extends React.Component<Props, State> {
     );
   }
 
-  private registerEvents(events: VCEvent[], idx: number, serieName: string) {
+  private buildLegendData(): LegendItem[] {
+    const items = this.props.data.map(s => {
+      if (this.state.hiddenSeries.has(s.legendItem.name)) {
+        return { ...s.legendItem, symbol: { ...s.legendItem.symbol, fill: '#72767b' } };
+      }
+      return s.legendItem;
+    });
+    if (this.props.overlay) {
+      let item = this.props.overlay.vcLine.legendItem;
+      if (this.state.hiddenSeries.has(overlayName)) {
+        item = { ...item, symbol: { ...item.symbol, fill: '#72767b' } };
+      }
+      items.push(item);
+    }
+    return items;
+  }
+
+  private registerEvents(events: VCEvent[], idx: number, serieID: string, serieName: string) {
     addLegendEvent(events, {
       legendName: 'serie-legend',
       idx: idx,
-      serieName: serieName,
+      serieID: serieID,
       onMouseOver: props => {
         return {
           style: {...props.style,  strokeWidth: 4, fillOpacity: 0.5}
         };
       },
       onClick: () => {
-        if (!this.state.hiddenSeries.delete(idx)) {
+        if (!this.state.hiddenSeries.delete(serieName)) {
           // Was not already hidden => add to set
-          this.state.hiddenSeries.add(idx);
+          this.state.hiddenSeries.add(serieName);
         }
         this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
         return null;

--- a/web/pf4/src/components/SparklineChart.tsx
+++ b/web/pf4/src/components/SparklineChart.tsx
@@ -76,7 +76,7 @@ export class SparklineChart extends React.Component<Props, State> {
         addLegendEvent(events, {
           legendName: this.props.name + '-legend',
           idx: idx,
-          serieName: this.props.name + '-area-' + idx,
+          serieID: this.props.name + '-area-' + idx,
           onClick: __ => {
             if (!this.state.hiddenSeries.delete(idx)) {
               // Was not already hidden => add to set

--- a/web/pf4/src/utils/events.ts
+++ b/web/pf4/src/utils/events.ts
@@ -1,7 +1,7 @@
 interface EventItem {
   legendName: string;
   idx: number;
-  serieName: string;
+  serieID: string;
   onClick?: (props: any) => any;
   onMouseOver?: (props: any) => any;
 }
@@ -31,12 +31,12 @@ export const addLegendEvent = (events: VCEvent[], item: EventItem): void => {
     eventHandlers.onClick = () => {
       return [
         {
-          childName: [item.serieName],
+          childName: [item.serieID],
           target: 'data',
           mutation: props => item.onClick!(props)
         },
         {
-          childName: [item.serieName],
+          childName: [item.serieID],
           target: 'data',
           eventKey: 'all',
           mutation: __ => null
@@ -48,7 +48,7 @@ export const addLegendEvent = (events: VCEvent[], item: EventItem): void => {
     eventHandlers.onMouseOver = () => {
       return [
         {
-          childName: [item.serieName],
+          childName: [item.serieID],
           target: 'data',
           eventKey: 'all',
           mutation: props => item.onMouseOver!(props)
@@ -58,7 +58,7 @@ export const addLegendEvent = (events: VCEvent[], item: EventItem): void => {
     eventHandlers.onMouseOut = () => {
       return [
         {
-          childName: [item.serieName],
+          childName: [item.serieID],
           target: 'data',
           eventKey: 'all',
           mutation: __ => null

--- a/web/pf4/src/utils/victoryChartsUtils.ts
+++ b/web/pf4/src/utils/victoryChartsUtils.ts
@@ -71,12 +71,12 @@ export const getDataSupplier = (chart: ChartModel, labels: LabelsInfo, colors: s
   return () => ([]);
 };
 
-export const buildLegendInfo = (series: VCLines, chartWidth: number): LegendInfo => {
+export const buildLegendInfo = (items: LegendItem[], chartWidth: number): LegendInfo => {
   // Very arbitrary rules to try to get a good-looking legend. There's room for enhancement.
   // Box size in pixels per item
   // Note that it is based on longest string in characters, not pixels
   let boxSize = 110;
-  const longest = series.map(it => it.legendItem.name).reduce((a, b) => a.length > b.length ? a : b, '').length;
+  const longest = items.map(it => it.name).reduce((a, b) => a.length > b.length ? a : b, '').length;
   if (longest >= 30) {
     boxSize = 400;
   } else if (longest >= 20) {
@@ -85,7 +85,7 @@ export const buildLegendInfo = (series: VCLines, chartWidth: number): LegendInfo
     boxSize = 200;
   }
   const itemsPerRow = Math.max(1, Math.floor(chartWidth / boxSize));
-  const nbRows = Math.ceil(series.length / itemsPerRow);
+  const nbRows = Math.ceil(items.length / itemsPerRow);
 
   return {
     height: 15 + 30 * nbRows,


### PR DESCRIPTION
Use name instead. So that hidden overlay will not mix up with other series when incoming props & number of series change

Fixes https://github.com/kiali/kiali/issues/2525

Note: there's an API change that needs an update in kiali-ui. To test within kiali, use: https://github.com/kiali/kiali-ui/pull/1695