### PR TITLE
Charts: click through tooltips

### DIFF
--- a/web/pf4/src/components/Container.tsx
+++ b/web/pf4/src/components/Container.tsx
@@ -13,10 +13,10 @@ export type BrushHandlers = {
   onDomainChangeEnd?: (domain: BrushDomain, props: any) => void
 };
 
-export const newBrushVoronoiContainer = (handlers?: BrushHandlers) => {
+export const newBrushVoronoiContainer = (onClick?: (event: any) => void, handlers?: BrushHandlers) => {
   const voronoiProps = {
     labels: obj => `${obj.datum.name}: ${getFormatter(d3Format, obj.datum.unit)(obj.datum.actualY || obj.datum.y)}`,
-    labelComponent: <CustomTooltip/>,
+    labelComponent: <CustomTooltip onClick={onClick} />,
     // We blacklist "parent" as a workaround to avoid the VictoryVoronoiContainer crashing.
     // See https://github.com/FormidableLabs/victory/issues/1355
     voronoiBlacklist: ['parent']

--- a/web/pf4/src/components/CustomTooltip.tsx
+++ b/web/pf4/src/components/CustomTooltip.tsx
@@ -42,6 +42,7 @@ export const CustomTooltip = (props: any) => {
       flyoutWidth={textWidth + 50}
       flyoutComponent={<Flyout style={{ stroke: 'none', fillOpacity: 0.6 }} />}
       labelComponent={<CustomLabel textWidth={textWidth}/>} constrainToVisibleArea={true}
+      events={props.onClick ? { onClick: props.onClick } : undefined}
     />
   );
 };


### PR DESCRIPTION
When onclick handler is defined, it must catch clicks through tooltips as well. Else, tooltip would prevent user to catch what is "behind" it.

Fixes https://github.com/kiali/kiali/issues/2527

Can be tested via storybook "ChartWithLegend as scatter plots", clicking on one of the plot where tooltip hides the plot:

![Capture d’écran de 2020-03-23 10-29-12](https://user-images.githubusercontent.com/2153442/77302305-6a9fd800-6cf1-11ea-8e4a-b353c9ba8833.png)
