### PR TITLE
Allow multiple metrics per chart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ matrix:
   include:
   - language: go
     go:
-    - 1.12.13
+    - 1.14
     install:
-    - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+    - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
     script:
     - make go
 

--- a/kubernetes/mock/mock.go
+++ b/kubernetes/mock/mock.go
@@ -28,12 +28,12 @@ func (o *ClientMock) GetDashboards(namespace string) ([]v1alpha1.MonitoringDashb
 
 func FakeChart(id, dataType string) v1alpha1.MonitoringDashboardChart {
 	return v1alpha1.MonitoringDashboardChart{
-		Name:       "My chart " + id,
-		Unit:       "s",
-		UnitScale:  10.0,
-		Spans:      6,
-		MetricName: "my_metric_" + id,
-		DataType:   dataType,
+		Name:      "My chart " + id,
+		Unit:      "s",
+		UnitScale: 10.0,
+		Spans:     6,
+		Metrics:   []v1alpha1.MonitoringDashboardMetric{{DisplayName: "My chart " + id, MetricName: "my_metric_" + id}},
+		DataType:  dataType,
 		Aggregations: []v1alpha1.MonitoringDashboardAggregation{
 			v1alpha1.MonitoringDashboardAggregation{
 				DisplayName: "Agg " + id,

--- a/kubernetes/v1alpha1/spec.go
+++ b/kubernetes/v1alpha1/spec.go
@@ -88,8 +88,9 @@ type MonitoringDashboardExternalLinkVariables struct {
 	Workload  string `json:"workload,omitempty"`
 }
 
+// GetMetrics provides consistent MonitoringDashboardMetric slice in a backward-compatible way, if deprecated field MetricName is used instead of Metrics in Spec.
 func (in *MonitoringDashboardChart) GetMetrics() []MonitoringDashboardMetric {
-	if in.MetricName != "" {
+	if len(in.Metrics) == 0 {
 		return []MonitoringDashboardMetric{
 			MonitoringDashboardMetric{
 				MetricName:  in.MetricName,

--- a/kubernetes/v1alpha1/spec.go
+++ b/kubernetes/v1alpha1/spec.go
@@ -58,9 +58,15 @@ type MonitoringDashboardChart struct {
 	Min          *int                             `json:"min"`
 	Max          *int                             `json:"max"`
 	MetricName   string                           `json:"metricName"`
+	Metrics      []MonitoringDashboardMetric      `json:"metrics"`
 	DataType     string                           `json:"dataType"`   // DataType is either "raw", "rate" or "histogram"
 	Aggregator   string                           `json:"aggregator"` // Aggregator can be set for raw data. Ex: "sum", "avg". See https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
 	Aggregations []MonitoringDashboardAggregation `json:"aggregations"`
+}
+
+type MonitoringDashboardMetric struct {
+	MetricName  string `json:"metricName"`
+	DisplayName string `json:"displayName"`
 }
 
 type MonitoringDashboardAggregation struct {
@@ -80,6 +86,18 @@ type MonitoringDashboardExternalLinkVariables struct {
 	Service   string `json:"service,omitempty"`
 	Version   string `json:"version,omitempty"`
 	Workload  string `json:"workload,omitempty"`
+}
+
+func (in *MonitoringDashboardChart) GetMetrics() []MonitoringDashboardMetric {
+	if in.MetricName != "" {
+		return []MonitoringDashboardMetric{
+			MonitoringDashboardMetric{
+				MetricName:  in.MetricName,
+				DisplayName: in.Name,
+			},
+		}
+	}
+	return in.Metrics
 }
 
 // TODO: auto-generate the following deepcopy methods!

--- a/kubernetes/v1alpha1/spec.go
+++ b/kubernetes/v1alpha1/spec.go
@@ -57,7 +57,7 @@ type MonitoringDashboardChart struct {
 	ChartType    *string                          `json:"chartType"`
 	Min          *int                             `json:"min"`
 	Max          *int                             `json:"max"`
-	MetricName   string                           `json:"metricName"`
+	MetricName   string                           `json:"metricName"` // Deprecated; use Metrics instead
 	Metrics      []MonitoringDashboardMetric      `json:"metrics"`
 	DataType     string                           `json:"dataType"`   // DataType is either "raw", "rate" or "histogram"
 	Aggregator   string                           `json:"aggregator"` // Aggregator can be set for raw data. Ex: "sum", "avg". See https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators

--- a/model/dashboards.go
+++ b/model/dashboards.go
@@ -10,6 +10,11 @@ import (
 	"github.com/kiali/k-charted/prometheus"
 )
 
+const (
+	statLabel = "__stat__"
+	nameLabel = "__name__"
+)
+
 // MonitoringDashboard is the model representing custom monitoring dashboard, transformed from MonitoringDashboard k8s resource
 type MonitoringDashboard struct {
 	Title         string         `json:"title"`
@@ -20,41 +25,57 @@ type MonitoringDashboard struct {
 
 // Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard k8s resource
 type Chart struct {
-	Name      string                     `json:"name"`
-	Unit      string                     `json:"unit"`
-	Spans     int                        `json:"spans"`
-	ChartType *string                    `json:"chartType,omitempty"`
-	Min       *int                       `json:"min,omitempty"`
-	Max       *int                       `json:"max,omitempty"`
-	Metric    []*SampleStream            `json:"metric"`
-	Histogram map[string][]*SampleStream `json:"histogram"`
-	Error     string                     `json:"error"`
+	Name      string          `json:"name"`
+	Unit      string          `json:"unit"`
+	Spans     int             `json:"spans"`
+	ChartType *string         `json:"chartType,omitempty"`
+	Min       *int            `json:"min,omitempty"`
+	Max       *int            `json:"max,omitempty"`
+	Metrics   []*SampleStream `json:"metrics"`
+	Error     string          `json:"error"`
 }
 
-func FillHistogram(from prometheus.Histogram, scale float64, name string, chart *Chart) {
-	stats := make(map[string][]*SampleStream, len(from))
-	for stat, metric := range from {
-		if metric.Err != nil {
-			chart.Error = fmt.Sprintf("error in metric %s/%s: %v", name, stat, metric.Err)
+func Labels(name, stat string) map[string]string {
+	labels := map[string]string{
+		nameLabel: name,
+	}
+	if stat != "" {
+		labels[statLabel] = stat
+	}
+	return labels
+}
+
+func (chart *Chart) FillHistogram(ref v1alpha1.MonitoringDashboardMetric, from prometheus.Histogram, scale float64) {
+	// Extract and sort keys for consistent oredering
+	stats := []string{}
+	for k := range from {
+		stats = append(stats, k)
+	}
+	sort.Strings(stats)
+	for _, stat := range stats {
+		promMetric := from[stat]
+		if promMetric.Err != nil {
+			chart.Error = fmt.Sprintf("error in metric %s/%s: %v", ref.MetricName, stat, promMetric.Err)
 			return
 		}
-		stats[stat] = ConvertMatrix(metric.Matrix, scale)
+		metric := ConvertMatrix(promMetric.Matrix, Labels(ref.DisplayName, stat), scale)
+		chart.Metrics = append(chart.Metrics, metric...)
 	}
-	chart.Histogram = stats
 }
 
-func FillMetric(from prometheus.Metric, scale float64, name string, chart *Chart) {
+func (chart *Chart) FillMetric(ref v1alpha1.MonitoringDashboardMetric, from prometheus.Metric, scale float64) {
 	if from.Err != nil {
-		chart.Error = fmt.Sprintf("error in metric %s: %v", name, from.Err)
+		chart.Error = fmt.Sprintf("error in metric %s: %v", ref.MetricName, from.Err)
 		return
 	}
-	chart.Metric = ConvertMatrix(from.Matrix, scale)
+	metric := ConvertMatrix(from.Matrix, Labels(ref.DisplayName, ""), scale)
+	chart.Metrics = append(chart.Metrics, metric...)
 }
 
-func ConvertMatrix(from pmod.Matrix, scale float64) []*SampleStream {
+func ConvertMatrix(from pmod.Matrix, initialLabels map[string]string, scale float64) []*SampleStream {
 	series := make([]*SampleStream, len(from))
 	for i, s := range from {
-		series[i] = convertSampleStream(s, scale)
+		series[i] = convertSampleStream(s, initialLabels, scale)
 	}
 	return series
 }
@@ -64,8 +85,11 @@ type SampleStream struct {
 	Values   []SamplePair      `json:"values"`
 }
 
-func convertSampleStream(from *pmod.SampleStream, scale float64) *SampleStream {
-	labelSet := make(map[string]string, len(from.Metric))
+func convertSampleStream(from *pmod.SampleStream, initialLabels map[string]string, scale float64) *SampleStream {
+	labelSet := make(map[string]string, len(from.Metric)+len(initialLabels))
+	for k, v := range initialLabels {
+		labelSet[k] = v
+	}
 	for k, v := range from.Metric {
 		labelSet[string(k)] = string(v)
 	}
@@ -108,6 +132,7 @@ func ConvertChart(from v1alpha1.MonitoringDashboardChart) Chart {
 		ChartType: from.ChartType,
 		Min:       from.Min,
 		Max:       from.Max,
+		Metrics:   []*SampleStream{},
 	}
 }
 

--- a/model/dashboards.go
+++ b/model/dashboards.go
@@ -35,7 +35,9 @@ type Chart struct {
 	Error     string          `json:"error"`
 }
 
-func Labels(name, stat string) map[string]string {
+// BuildLabelsMap initiates a labels map out of a given metric name and optionally histogram stat
+// Exported for external usage (Kiali)
+func BuildLabelsMap(name, stat string) map[string]string {
 	labels := map[string]string{
 		nameLabel: name,
 	}
@@ -46,7 +48,7 @@ func Labels(name, stat string) map[string]string {
 }
 
 func (chart *Chart) FillHistogram(ref v1alpha1.MonitoringDashboardMetric, from prometheus.Histogram, scale float64) {
-	// Extract and sort keys for consistent oredering
+	// Extract and sort keys for consistent ordering
 	stats := []string{}
 	for k := range from {
 		stats = append(stats, k)
@@ -58,7 +60,7 @@ func (chart *Chart) FillHistogram(ref v1alpha1.MonitoringDashboardMetric, from p
 			chart.Error = fmt.Sprintf("error in metric %s/%s: %v", ref.MetricName, stat, promMetric.Err)
 			return
 		}
-		metric := ConvertMatrix(promMetric.Matrix, Labels(ref.DisplayName, stat), scale)
+		metric := ConvertMatrix(promMetric.Matrix, BuildLabelsMap(ref.DisplayName, stat), scale)
 		chart.Metrics = append(chart.Metrics, metric...)
 	}
 }
@@ -68,7 +70,7 @@ func (chart *Chart) FillMetric(ref v1alpha1.MonitoringDashboardMetric, from prom
 		chart.Error = fmt.Sprintf("error in metric %s: %v", ref.MetricName, from.Err)
 		return
 	}
-	metric := ConvertMatrix(from.Matrix, Labels(ref.DisplayName, ""), scale)
+	metric := ConvertMatrix(from.Matrix, BuildLabelsMap(ref.DisplayName, ""), scale)
 	chart.Metrics = append(chart.Metrics, metric...)
 }
 

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -141,6 +141,8 @@ func roundSignificant(innerQuery string, precision float64) string {
 }
 
 // evictNaN will evict NaN datapoints (which aren't summable) from the series, with a little trick got from https://stackoverflow.com/a/58384750/3697695
+// Such undesirable NaN values can be observed, for instance, on aggregated metrics out of recording rules in Prometheus config.
+// Without evicting, they would "spread" on datapoints when summed.
 func evictNaN(query string) string {
 	return fmt.Sprintf("%s == %s", query, query)
 }

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -49,7 +49,7 @@ func NewClient(cfg extconfig.PrometheusConfig) (*Client, error) {
 
 // FetchRange fetches a simple metric (gauge or counter) in given range
 func (in *Client) FetchRange(metricName, labels, grouping, aggregator string, q *MetricsQuery) Metric {
-	query := fmt.Sprintf("%s(%s%s)", aggregator, metricName, labels)
+	query := fmt.Sprintf("%s(%s)", aggregator, evictNaN(metricName+labels))
 	if grouping != "" {
 		query += fmt.Sprintf(" by (%s)", grouping)
 	}
@@ -61,10 +61,11 @@ func (in *Client) FetchRange(metricName, labels, grouping, aggregator string, q 
 func (in *Client) FetchRateRange(metricName, labels, grouping string, q *MetricsQuery) Metric {
 	var query string
 	// Example: round(sum(rate(my_counter{foo=bar}[5m])) by (baz), 0.001)
+	innerQuery := evictNaN(fmt.Sprintf("%s%s[%s]", metricName, labels, q.RateInterval))
 	if grouping == "" {
-		query = fmt.Sprintf("sum(%s(%s%s[%s]))", q.RateFunc, metricName, labels, q.RateInterval)
+		query = fmt.Sprintf("sum(%s(%s))", q.RateFunc, innerQuery)
 	} else {
-		query = fmt.Sprintf("sum(%s(%s%s[%s])) by (%s)", q.RateFunc, metricName, labels, q.RateInterval, grouping)
+		query = fmt.Sprintf("sum(%s(%s)) by (%s)", q.RateFunc, innerQuery, grouping)
 	}
 	query = roundSignificant(query, 0.001)
 	return in.fetchRange(query, q.Range)
@@ -137,4 +138,9 @@ func (in *Client) GetMetricsForLabels(labels []string) ([]string, error) {
 // roundSignificant will output promQL that performs rounding only if the resulting value is significant, that is, higher than the requested precision
 func roundSignificant(innerQuery string, precision float64) string {
 	return fmt.Sprintf("round(%s, %f) > %f or %s", innerQuery, precision, precision, innerQuery)
+}
+
+// evictNaN will evict NaN datapoints (which aren't summable) from the series, with a little trick got from https://stackoverflow.com/a/58384750/3697695
+func evictNaN(query string) string {
+	return fmt.Sprintf("%s == %s", query, query)
 }

--- a/prometheus/mock/mock.go
+++ b/prometheus/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/kiali/k-charted/prometheus"
@@ -28,4 +29,22 @@ func (o *PromClientMock) FetchHistogramRange(metricName, labels, grouping string
 func (o *PromClientMock) GetMetricsForLabels(labels []string) ([]string, error) {
 	args := o.Called(labels)
 	return args.Get(0).([]string), args.Error(1)
+}
+
+func FakeCounter(value int) prometheus.Metric {
+	return prometheus.Metric{
+		Matrix: model.Matrix{
+			&model.SampleStream{
+				Metric: model.Metric{},
+				Values: []model.SamplePair{model.SamplePair{Timestamp: 0, Value: model.SampleValue(value)}},
+			},
+		},
+	}
+}
+
+func FakeHistogram(avg, p99 int) prometheus.Histogram {
+	return prometheus.Histogram{
+		"0.99": FakeCounter(p99),
+		"avg":  FakeCounter(avg),
+	}
 }

--- a/web/common/types/Dashboards.ts
+++ b/web/common/types/Dashboards.ts
@@ -1,4 +1,4 @@
-import { TimeSeries, Histogram } from './Metrics';
+import { TimeSeries } from './Metrics';
 import { PromLabel, LabelDisplayName } from './Labels';
 
 export interface DashboardModel {
@@ -18,8 +18,7 @@ export interface ChartModel {
   chartType?: ChartType;
   min?: number;
   max?: number;
-  metric?: TimeSeries[];
-  histogram?: Histogram;
+  metrics: TimeSeries[];
   error?: string;
 }
 

--- a/web/common/types/Labels.ts
+++ b/web/common/types/Labels.ts
@@ -10,3 +10,6 @@ export type AllPromLabelsValues = Map<PromLabel, SingleLabelValues>;
 export type LabelSet = {
   [key: string]: string;
 };
+
+export const nameLabel = '__name__';
+export const statLabel = '__stat__';

--- a/web/common/types/Metrics.ts
+++ b/web/common/types/Metrics.ts
@@ -6,7 +6,8 @@ export type Datapoint = [number, number];
 export interface TimeSeries {
   labelSet: LabelSet;
   values: Datapoint[];
-  name?: string;
 }
 
-export type Histogram = { [key: string]: TimeSeries[] };
+export interface NamedTimeSeries extends TimeSeries {
+  name: string;
+}

--- a/web/pf4/src/types/__mocks__/Dashboards.mock.ts
+++ b/web/pf4/src/types/__mocks__/Dashboards.mock.ts
@@ -1,6 +1,6 @@
 import { DashboardModel } from '../../../../common/types/Dashboards';
 import seedrandom from 'seedrandom';
-import { generateRandomMetricChart, generateRandomMetricChartWithLabels, generateRandomHistogramChart, generateRandomScatterChart } from './Charts.mock';
+import { generateRandomMetricChart, generateRandomMetricChartWithLabels, generateRandomHistogramChart, generateRandomScatterChart, genLabels } from './Charts.mock';
 
 export const generateRandomDashboard = (title: string, seed?: string): DashboardModel => {
   if (seed) {
@@ -9,13 +9,21 @@ export const generateRandomDashboard = (title: string, seed?: string): Dashboard
   return {
     title: title,
     charts: [
-      generateRandomMetricChart('Best animal', ['dogs', 'cats', 'birds'], 4),
-      generateRandomMetricChartWithLabels('Best fruit', [{name: 'apples', labels: {color: 'green'}}, {name: 'oranges', labels: {color: 'orange'}}, {name: 'bananas', labels: {color: 'yellow'}}], 4),
+      generateRandomMetricChart('Single metric', ['chocolate'], 4),
+      generateRandomMetricChartWithLabels('Single metric with labels', [
+        genLabels('apples', undefined, [['color', 'green'], ['size', 'big']])
+      ], 4),
       generateRandomHistogramChart('Histogram', 4),
-      { name: 'empty 1', unit: 'bytes', spans: 6, metric: [] },
-      { name: 'empty 2', unit: 'bytes', spans: 6, metric: [] },
-      { name: 'error 1', unit: 'bytes', spans: 6, metric: [], error: 'Unexpected error occurred ... blah blah blah' },
-      { name: 'error 2', unit: 'bytes', spans: 6, metric: [], error: 'Unexpected error occurred ... blah blah blah' },
+      generateRandomMetricChart('Several metrics', ['dogs', 'cats', 'birds'], 6),
+      generateRandomMetricChartWithLabels('Several metrics with labels', [
+        genLabels('apples', undefined, [['color', 'green'], ['size', 'big']]),
+        genLabels('oranges', undefined, [['color', 'orange'], ['size', 'small']]),
+        genLabels('bananas', undefined, [['color', 'yellow'], ['size', 'medium']])
+      ], 6),
+      { name: 'empty 1', unit: 'bytes', spans: 6, metrics: [] },
+      { name: 'empty 2', unit: 'bytes', spans: 6, metrics: [] },
+      { name: 'error 1', unit: 'bytes', spans: 6, metrics: [], error: 'Unexpected error occurred ... blah blah blah' },
+      { name: 'error 2', unit: 'bytes', spans: 6, metrics: [], error: 'Unexpected error occurred ... blah blah blah' },
       generateRandomMetricChart('Best animal++', ['dogs', 'cats', 'birds', 'stunning animal with very very long name that you\'ve never about', 'mermaids', 'escherichia coli', 'wohlfahrtiimonas', 'Chuck Norris'], 4),
       generateRandomMetricChart('Best fruit++', ['apples', 'oranges', 'bananas', 'peaches', 'peers', 'cherries', 'leetchies', 'pineapple'], 4),
       generateRandomScatterChart('Best traces++', ['apples', 'oranges', 'bananas', 'peaches', 'peers', 'cherries', 'leetchies', 'pineapple'], 4),

--- a/web/pf4/src/utils/__tests__/victoryChartsUtils.test.ts
+++ b/web/pf4/src/utils/__tests__/victoryChartsUtils.test.ts
@@ -38,7 +38,7 @@ describe('Victory Charts Utils', () => {
       name: '',
       unit: '',
       spans: 6,
-      metric: [{
+      metrics: [{
         values: [[1, 1], [2, 2], [3, NaN], [4, 4]],
         labelSet: {}
       }]


### PR DESCRIPTION
- Changed MonitoringDashboard Spec: new "Metrics" field (list of metrics within a chart)
  o Backward-compatible from user point of view (no need to update dashboards)...
  o But breaking change from developer point of view, consuming side (Kiali) needs to adapt
- Updated fetching process
- Updated model on front/back interface: removed distinction "metric vs histogram", now there's several metrics and histograms are just a (not-so-)special case of that
- Updated tests, both front and back; updated front stories

Fixes https://github.com/kiali/kiali/issues/1778