### PR TITLE
Allow series-based x-axis

### DIFF
--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -47,7 +47,7 @@ func TestGetDashboard(t *testing.T) {
 			"APP": "my-app",
 		},
 		AdditionalLabels: []model.Aggregation{
-			model.Aggregation{
+			{
 				Label:       "version",
 				DisplayName: "Version",
 			},
@@ -229,10 +229,10 @@ func fakeDashboard(id string) *v1alpha1.MonitoringDashboard {
 			Runtime:    "Runtime " + id,
 			DiscoverOn: "my_metric_" + id + "_1",
 			Items: []v1alpha1.MonitoringDashboardItem{
-				v1alpha1.MonitoringDashboardItem{
+				{
 					Chart: kmock.FakeChart(id+"_1", "rate"),
 				},
-				v1alpha1.MonitoringDashboardItem{
+				{
 					Chart: kmock.FakeChart(id+"_2", "histogram"),
 				},
 			},

--- a/kubernetes/v1alpha1/spec.go
+++ b/kubernetes/v1alpha1/spec.go
@@ -63,6 +63,7 @@ type MonitoringDashboardChart struct {
 	DataType       string                           `json:"dataType"`   // DataType is either "raw", "rate" or "histogram"
 	Aggregator     string                           `json:"aggregator"` // Aggregator can be set for raw data. Ex: "sum", "avg". See https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
 	Aggregations   []MonitoringDashboardAggregation `json:"aggregations"`
+	XAxis          *string                          `json:"xAxis"` // "time" (default) or "series"
 }
 
 type MonitoringDashboardMetric struct {
@@ -93,7 +94,7 @@ type MonitoringDashboardExternalLinkVariables struct {
 func (in *MonitoringDashboardChart) GetMetrics() []MonitoringDashboardMetric {
 	if len(in.Metrics) == 0 {
 		return []MonitoringDashboardMetric{
-			MonitoringDashboardMetric{
+			{
 				MetricName:  in.MetricName,
 				DisplayName: in.Name,
 			},

--- a/model/dashboards.go
+++ b/model/dashboards.go
@@ -33,6 +33,7 @@ type Chart struct {
 	Min            *int            `json:"min,omitempty"`
 	Max            *int            `json:"max,omitempty"`
 	Metrics        []*SampleStream `json:"metrics"`
+	XAxis          *string         `json:"xAxis"`
 	Error          string          `json:"error"`
 }
 
@@ -137,6 +138,7 @@ func ConvertChart(from v1alpha1.MonitoringDashboardChart) Chart {
 		Min:            from.Min,
 		Max:            from.Max,
 		Metrics:        []*SampleStream{},
+		XAxis:          from.XAxis,
 	}
 }
 

--- a/prometheus/mock/mock.go
+++ b/prometheus/mock/mock.go
@@ -36,7 +36,7 @@ func FakeCounter(value int) prometheus.Metric {
 		Matrix: model.Matrix{
 			&model.SampleStream{
 				Metric: model.Metric{},
-				Values: []model.SamplePair{model.SamplePair{Timestamp: 0, Value: model.SampleValue(value)}},
+				Values: []model.SamplePair{{Timestamp: 0, Value: model.SampleValue(value)}},
 			},
 		},
 	}

--- a/web/common/types/Dashboards.ts
+++ b/web/common/types/Dashboards.ts
@@ -10,6 +10,7 @@ export interface DashboardModel {
 
 export type SpanValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 export type ChartType = 'area' | 'line' | 'bar' | 'scatter';
+export type XAxisType = 'time' | 'series';
 
 export interface ChartModel {
   name: string;
@@ -21,6 +22,7 @@ export interface ChartModel {
   metrics: TimeSeries[];
   error?: string;
   startCollapsed: boolean;
+  xAxis?: XAxisType;
 }
 
 export interface AggregationModel {

--- a/web/pf4/src/components/Container.tsx
+++ b/web/pf4/src/components/Container.tsx
@@ -25,6 +25,9 @@ const formatValue = (label: string, datum: RichDataPoint, value: number) => {
 export const newBrushVoronoiContainer = (onClick?: (event: MouseEvent) => void, handlers?: BrushHandlers) => {
   const voronoiProps = {
     labels: obj => {
+      if (obj.datum.hideLabel) {
+        return undefined;
+      }
       if (obj.datum._median !== undefined) {
         // Buckets display => datapoint is expected to have _median, _min, _max, _q1, _q3 stats
         const avg = obj.datum.y.reduce((s, y) => s + y, 0) / obj.datum.y.length;

--- a/web/pf4/src/components/CustomTooltip.tsx
+++ b/web/pf4/src/components/CustomTooltip.tsx
@@ -15,7 +15,7 @@ export const CustomLabel = (props: any & { textWidth: number }) => {
   const startY = 8 + props.y - (nbTexts * dy) / 2;
   return (
     <>
-      {props.activePoints && props.activePoints.filter(pt => pt.color)
+      {props.activePoints && props.activePoints.filter(pt => pt.color && !pt.hideLabel)
         .map((pt, idx) => {
           const symbol = pt.symbol || 'square';
           return (

--- a/web/pf4/src/components/KChart.stories.tsx
+++ b/web/pf4/src/components/KChart.stories.tsx
@@ -6,6 +6,7 @@ import { empty, error, generateRandomMetricChart, generateRandomHistogramChart, 
 
 import '@patternfly/react-core/dist/styles/base.css';
 import { LineInfo } from '../types/VictoryChartInfo';
+import { ChartModel } from '..';
 
 const metric = generateRandomMetricChart('Random metric chart', ['dogs', 'cats', 'birds'], 12, 'kchart-seed');
 const histogram = generateRandomHistogramChart('Random histogram chart', 12, 'kchart-histo-seed');
@@ -112,5 +113,15 @@ storiesOf('PF4 KChart', module)
   .add('start collapsed', () => {
     reset();
     const chart = { ...metric, startCollapsed: true };
-    return <KChart {...defaultProps} chart={chart} data={getDataSupplier(metric, emptyLabels, colors)!()} />;
+    return <KChart {...defaultProps} chart={chart} data={getDataSupplier(chart, emptyLabels, colors)!()} />;
+  })
+  .add('scatter with x-axis as series', () => {
+    reset();
+    const chart: ChartModel = { ...metric, chartType: 'scatter', xAxis: 'series' };
+    return <KChart {...defaultProps} chart={chart} data={getDataSupplier(chart, emptyLabels, colors)!()} />;
+  })
+  .add('bar with x-axis as series', () => {
+    reset();
+    const chart: ChartModel = { ...metric, chartType: 'bar', xAxis: 'series' };
+    return <KChart {...defaultProps} chart={chart} data={getDataSupplier(chart, emptyLabels, colors)!()} />;
   });

--- a/web/pf4/src/components/KChart.tsx
+++ b/web/pf4/src/components/KChart.tsx
@@ -33,6 +33,43 @@ type State = {
   collapsed: boolean
 };
 
+type ChartTypeData = {
+  fill: boolean,
+  stroke: boolean,
+  groupOffset: number,
+  seriesComponent: React.ReactElement,
+  sizeRatio: number
+};
+
+const lineInfo: ChartTypeData = {
+  fill: false,
+  stroke: true,
+  groupOffset: 0,
+  seriesComponent: <ChartLine/>,
+  sizeRatio: 1.0
+};
+const areaInfo: ChartTypeData = {
+  fill: true,
+  stroke: false,
+  groupOffset: 0,
+  seriesComponent: <ChartArea/>,
+  sizeRatio: 1.0
+}
+const barInfo: ChartTypeData = {
+  fill: true,
+  stroke: false,
+  groupOffset: 7,
+  seriesComponent: <ChartBar/>,
+  sizeRatio: 1/6
+};
+const scatterInfo: ChartTypeData = {
+  fill: true,
+  stroke: false,
+  groupOffset: 0,
+  seriesComponent: <ChartScatter/>,
+  sizeRatio: 1/30
+};
+
 class KChart<T extends LineInfo> extends React.Component<KChartProps<T>, State> {
   constructor(props: KChartProps<T>) {
     super(props);
@@ -57,28 +94,29 @@ class KChart<T extends LineInfo> extends React.Component<KChartProps<T>, State> 
     );
   }
 
-  renderChart() {
+  private determineChartType() {
+    if (this.props.chart.chartType === undefined) {
+      return this.props.chart.xAxis === 'series' ? barInfo : lineInfo;
+    }
+    const chartType = this.props.chart.chartType;
+    switch (chartType) {
+      case 'area':
+        return areaInfo;
+      case 'bar':
+        return barInfo;
+      case 'scatter':
+        return scatterInfo;
+      case 'line':
+      default:
+        return lineInfo;
+    }
+  }
+
+  private renderChart() {
     if (this.state.collapsed) {
       return undefined;
     }
-    let fill = false;
-    let stroke = true;
-    let seriesComponent = (<ChartLine/>);
-    if (this.props.chart.chartType === 'area') {
-      fill = true;
-      stroke = false;
-      seriesComponent = (<ChartArea/>);
-    } else if (this.props.chart.chartType === 'bar') {
-      fill = true;
-      stroke = false;
-      seriesComponent = (<ChartBar/>);
-    } else if (this.props.chart.chartType === 'scatter') {
-      fill = true;
-      stroke = false;
-      seriesComponent = (<ChartScatter/>);
-    }
-
-    const groupOffset = this.props.chart.chartType === 'bar' ? 7 : 0;
+    const typeData = this.determineChartType();
     const minDomain = this.props.chart.min === undefined ? undefined : { y: this.props.chart.min };
     const maxDomain = this.props.chart.max === undefined ? undefined : { y: this.props.chart.max };
 
@@ -93,16 +131,18 @@ class KChart<T extends LineInfo> extends React.Component<KChartProps<T>, State> 
         )}
         <ChartWithLegend
           data={this.props.data}
-          seriesComponent={seriesComponent}
-          fill={fill}
-          stroke={stroke}
-          groupOffset={groupOffset}
+          seriesComponent={typeData.seriesComponent}
+          fill={typeData.fill}
+          stroke={typeData.stroke}
+          groupOffset={typeData.groupOffset}
+          sizeRatio={typeData.sizeRatio}
           overlay={this.props.overlay}
           unit={this.props.chart.unit}
           moreChartProps={{ minDomain: minDomain, maxDomain: maxDomain }}
           onClick={this.props.onClick}
           brushHandlers={this.props.brushHandlers}
           timeWindow={this.props.timeWindow}
+          xAxis={this.props.chart.xAxis}
         />
       </>
     );

--- a/web/pf4/src/types/__mocks__/Dashboards.mock.ts
+++ b/web/pf4/src/types/__mocks__/Dashboards.mock.ts
@@ -27,6 +27,8 @@ export const generateRandomDashboard = (title: string, seed?: string): Dashboard
       generateRandomMetricChart('Best animal++', ['dogs', 'cats', 'birds', 'stunning animal with very very long name that you\'ve never about', 'mermaids', 'escherichia coli', 'wohlfahrtiimonas', 'Chuck Norris'], 4),
       generateRandomMetricChart('Best fruit++', ['apples', 'oranges', 'bananas', 'peaches', 'peers', 'cherries', 'leetchies', 'pineapple'], 4),
       generateRandomScatterChart('Best traces++', ['apples', 'oranges', 'bananas', 'peaches', 'peers', 'cherries', 'leetchies', 'pineapple'], 4),
+      { ...generateRandomMetricChart('With x-axis as series', ['dogs', 'cats', 'birds'], 6), xAxis: 'series' },
+      { ...generateRandomMetricChart('Bars with x-axis as series', ['apples', 'oranges', 'bananas', 'peaches', 'peers', 'cherries', 'leetchies', 'pineapple'], 6), xAxis: 'series', chartType: 'bar' },
     ],
     aggregations: [],
     externalLinks: []


### PR DESCRIPTION
- New "xAxis" field in monitoringdashboard CR under Spec.Charts, which can be either time or series (default=time)
- When this field is "series", chart is forced as bar chart with a couple of specific render options (bar width, domain padding...) and x-axis being linear scale with special tick values
- New stories in storybook: KChart "with x-axis as series" and Dashboard with a chart with x-axis as series

Fixes https://github.com/kiali/kiali/issues/2993