### PR TITLE
Hide x tick labels when xaxis type is 'series'

### DIFF
--- a/web/pf4/src/components/ChartWithLegend.tsx
+++ b/web/pf4/src/components/ChartWithLegend.tsx
@@ -136,6 +136,7 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
               domain={[0, filteredData.length + 1]}
               style={{ tickLabels: {fontSize: 12, padding: 2} }}
               tickValues={filteredData.map(s => s.legendItem.name)}
+              tickFormat={_ => ''}
             />
           ) : (
             <ChartAxis


### PR DESCRIPTION
Because it's redundant with legend

Fixes https://github.com/kiali/kiali/issues/3077

Screenshot (storybook) :
![Capture d’écran de 2020-08-04 16-18-38](https://user-images.githubusercontent.com/2153442/89305078-7bccfe00-d66e-11ea-8663-ae0dfdc8258c.png)
