### PR TITLE
On click handler: use tooltip-focused datapoint

### DIFF
--- a/web/pf4/src/components/Container.tsx
+++ b/web/pf4/src/components/Container.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { format as d3Format } from 'd3-format';
 import { getFormatter } from '../../../common/utils/formatter';
 import { CustomTooltip } from './CustomTooltip';
-import { RichDataPoint } from '../types/VictoryChartInfo';
+import { RichDataPoint, VCDataPoint } from '../types/VictoryChartInfo';
 
 import { VictoryVoronoiContainer, createContainer } from 'victory';
 
@@ -22,7 +22,7 @@ const formatValue = (label: string, datum: RichDataPoint, value: number) => {
   return label + ': ' + getFormatter(d3Format, datum.unit!)(value / (datum.scaleFactor || 1));
 };
 
-export const newBrushVoronoiContainer = (onClick?: (event: MouseEvent) => void, handlers?: BrushHandlers) => {
+export const newBrushVoronoiContainer = (onTooltipOpen: (items: VCDataPoint[]) => void, onTooltipClose: () => void, handlers?: BrushHandlers) => {
   const voronoiProps = {
     labels: obj => {
       if (obj.datum.hideLabel) {
@@ -37,7 +37,7 @@ export const newBrushVoronoiContainer = (onClick?: (event: MouseEvent) => void, 
       }
       return formatValue(obj.datum.name, obj.datum, obj.datum.y);
     },
-    labelComponent: <CustomTooltip showTime={true} onClick={onClick} />,
+    labelComponent: <CustomTooltip showTime={true} onOpen={onTooltipOpen} onClose={onTooltipClose} />,
     // We blacklist "parent" as a workaround to avoid the VictoryVoronoiContainer crashing.
     // See https://github.com/FormidableLabs/victory/issues/1355
     voronoiBlacklist: ['parent']

--- a/web/pf4/src/utils/__tests__/victoryChartsUtils.test.ts
+++ b/web/pf4/src/utils/__tests__/victoryChartsUtils.test.ts
@@ -1,7 +1,7 @@
-import { getDataSupplier, findClosestDatapoint, toBuckets } from '../victoryChartsUtils';
+import { getDataSupplier, toBuckets } from '../victoryChartsUtils';
 import { empty, histogram, metric, metricWithLabels, emptyLabels, labelsWithPrettifier } from '../../types/__mocks__/Charts.mock';
 import { ChartModel } from '../..';
-import { RawOrBucket, LineInfo } from '../../types/VictoryChartInfo';
+import { LineInfo } from '../../types/VictoryChartInfo';
 
 const t0 = new Date('2019-05-02T13:00:00.000Z');
 const t1 = new Date('2019-05-02T13:01:00.000Z');
@@ -58,40 +58,6 @@ describe('Victory Charts Utils', () => {
     expect(res[0].datapoints.map(s => s.name)).toEqual(['OK']);
     expect(res[1].datapoints.map(s => s.name)).toEqual(['No content']);
     expect(res[2].datapoints.map(s => s.name)).toEqual(['foobar']);
-  });
-
-  it('should find closest data point', () => {
-    const lines = [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }] as RawOrBucket<LineInfo>[];
-    // Remember that screen Y coordinate is reversed compared to domain!
-    let point = findClosestDatapoint(lines, -50, -50, 10, 10);
-    expect(point).toEqual({x: 0, y: 1});
-    point = findClosestDatapoint(lines, 2, 0, 10, 10);
-    expect(point).toEqual({x: 0, y: 1});
-    point = findClosestDatapoint(lines, 7, 3, 10, 10);
-    expect(point).toEqual({x: 1, y: 1});
-    point = findClosestDatapoint(lines, 2, 12, 10, 10);
-    expect(point).toEqual({x: 0, y: 0});
-  });
-
-  it('should not crash while finding closest data point', () => {
-    let point = findClosestDatapoint([] as RawOrBucket<LineInfo>[], 50, 50, 500, 500);
-    expect(point).toBeUndefined();
-
-    point = findClosestDatapoint([{ x: 0, y: 0 }] as RawOrBucket<LineInfo>[], 50, 50, 0, 0);
-    expect(point).toBeUndefined();
-  });
-
-  it('should find closest data point with different axis scales', () => {
-    const lines = [{ x: 10000, y: 0 }, { x: 20000, y: 0 }, { x: 10005, y: 1 }, { x: 20005, y: 1 }] as RawOrBucket<LineInfo>[];
-    // Remember that screen Y coordinate is reversed compared to domain!
-    let point = findClosestDatapoint(lines, -50, -50, 10, 10);
-    expect(point).toEqual({x: 10005, y: 1});
-    point = findClosestDatapoint(lines, 2, 0, 10, 10);
-    expect(point).toEqual({x: 10005, y: 1});
-    point = findClosestDatapoint(lines, 7, 3, 10, 10);
-    expect(point).toEqual({x: 20005, y: 1});
-    point = findClosestDatapoint(lines, 2, 12, 10, 10);
-    expect(point).toEqual({x: 10000, y: 0});
   });
 
   it('should build empty buckets', () => {

--- a/web/pf4/src/utils/events.ts
+++ b/web/pf4/src/utils/events.ts
@@ -30,7 +30,8 @@ type EventMutation = {
 export const addLegendEvent = (events: VCEvent[], item: EventItem): void => {
   const eventHandlers: EventHandlers = {};
   if (item.onClick) {
-    eventHandlers.onClick = () => {
+    eventHandlers.onClick = e => {
+      e.stopPropagation();
       return [
         {
           childName: [item.serieID],


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3171

Change the click-focus detection: instead of trying to re-compute closest point based on mouse position, data and domain projection, store & retrieve whatever is selected (mouse-over) when tooltip pops up. This method seems much more reliable.

However as a consequence, since clicking now depends on tooltip being displayed, deactivating tooltips would also deactivate onclick hooks. But as of today this is not a problem in Kiali.