### PR TITLE
Provide better control over styles

### DIFF
--- a/web/pf4/src/components/ChartWithLegend.stories.tsx
+++ b/web/pf4/src/components/ChartWithLegend.stories.tsx
@@ -91,4 +91,20 @@ storiesOf('ChartWithLegend', module)
   })
   .add('with crossing point', () => {
     return <ChartWithLegend data={crossing} unit="seconds" stroke={true} seriesComponent={(<ChartLine/>)} />;
+  })
+  .add('with style override', () => {
+    return (
+      <ChartWithLegend
+        data={[traces]}
+        unit="seconds"
+        seriesComponent={(<ChartScatter style={{ data: {
+          fill: 'blue',
+          stroke: dp => (dp && dp.size > 5) ? 'orange' : undefined,
+          strokeWidth: 3,
+          opacity: dp => (dp && dp.size === 5) ? 0.2 : undefined
+        }}}/>)}
+        onClick={dp => alert(`${dp.name}: [${dp.x}, ${dp.y}]`)}
+        overrideSeriesComponentStyle={false}
+      />
+    );
   });

--- a/web/pf4/src/components/ChartWithLegend.tsx
+++ b/web/pf4/src/components/ChartWithLegend.tsx
@@ -15,6 +15,7 @@ type Props<T extends RichDataPoint, O extends LineInfo> = {
   chartHeight?: number;
   data: VCLines<T & VCDataPoint>;
   seriesComponent: React.ReactElement;
+  overrideSeriesComponentStyle?: boolean;
   stroke?: boolean;
   fill?: boolean;
   groupOffset?: number;
@@ -212,12 +213,11 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
           if (this.state.hiddenSeries.has(serie.legendItem.name)) {
             return undefined;
           }
-          return React.cloneElement(this.props.seriesComponent, {
+          return React.cloneElement(this.props.seriesComponent, this.withStyle({
             key: 'serie-' + idx,
             name: 'serie-' + idx,
             data: serie.datapoints,
-            style: { data: { fill: this.props.fill ? serie.color : undefined, stroke: this.props.stroke ? serie.color : undefined }},
-          });
+          }, serie.color));
         })}
       </ChartGroup>
     );    
@@ -231,15 +231,21 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
       if (this.state.hiddenSeries.has(serie.legendItem.name)) {
         return undefined;
       }
-      return React.cloneElement(this.props.seriesComponent, {
+      return React.cloneElement(this.props.seriesComponent, this.withStyle({
         key: 'serie-' + idx,
         name: 'serie-' + idx,
         data: serie.datapoints.map(d => ({ size: size, ...d, x: domainX++ })),
-        style: { data: { fill: this.props.fill ? serie.color : undefined, stroke: this.props.stroke ? serie.color : undefined }},
         barWidth: size
-      });
+      }, serie.color));
     });
   }
+
+  private withStyle = (props: any, color?: string) => {
+    return this.props.overrideSeriesComponentStyle === false ? props : {
+      ...props,
+      style: { data: { fill: this.props.fill ? color : undefined, stroke: this.props.stroke ? color : undefined }}
+    };
+  };
 
   private handleResize = () => {
     if (this.containerRef && this.containerRef.current) {


### PR DESCRIPTION
- When ChartWithLegend has props overrideSeriesComponentStyle set to false, it will not try to apply any style (it defaults to true)...
- ... which allows the caller to provide its own style directly in the seriesComponent props
- Example of use in storybook "ChartWithLegend > with style override"

Storybook:
![Capture d’écran de 2020-09-17 16-10-20](https://user-images.githubusercontent.com/2153442/93483459-1cb30800-f901-11ea-9fae-905f50833947.png)
