### PR TITLE
Wrong z-index for refresh controller

### DIFF
--- a/web/pf4/src/components/KChart.tsx
+++ b/web/pf4/src/components/KChart.tsx
@@ -24,7 +24,6 @@ export const maximizeButtonStyle: React.CSSProperties = {
   marginBottom: '-3.5em',
   marginRight: '0.8em',
   top: '-2.7em',
-  zIndex: 1,
   position: 'relative',
   float: 'right'
 };


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3307

Before:
![image](https://user-images.githubusercontent.com/1662329/96163341-1329b980-0f1a-11eb-97ae-702431b9ddd8.png)
```
margin-bottom: -3.5em; margin-right: 0.8em; top: -2.7em; z-index: 1; position: relative; float: right;
```

After:
![image](https://user-images.githubusercontent.com/1662329/96163469-381e2c80-0f1a-11eb-9ecc-5636f2ae41d7.png)
```
margin-bottom: -3.5em; margin-right: 0.8em; top: -2.7em; position: relative; float: right;
```

Storybook seems without side effects:
![image](https://user-images.githubusercontent.com/1662329/96163596-5f74f980-0f1a-11eb-9faf-8dee70fcf73b.png)
