### PR TITLE
README: mention discontinued project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# -- DISCONTINUED REPOSITORY --
+
+The K-charted source code has been merged in Kiali main repositories (kiali and kiali-ui). This repository should not receive any (non-critical) update further on.
+
 # K-Charted
 
 Dashboards and Charts library for Kubernetes, to use with `MonitoringDashboard` custom resources as [documented in Kiali](https://www.kiali.io/documentation/runtimes-monitoring/#_create_new_dashboards).


### PR DESCRIPTION
Note, I don't think we should archive this repository right now (ie. make it read-only) as it's still used in some previous versions of kiali that are, if I'm correct, still under support.